### PR TITLE
Fix shell injection bug in `std.urlGet`

### DIFF
--- a/quickjs-libc.c
+++ b/quickjs-libc.c
@@ -1274,7 +1274,7 @@ static JSValue js_std_file_putByte(JSContext *ctx, JSValueConst this_val,
 
 /* urlGet */
 
-#define URL_GET_PROGRAM "curl -s -i"
+#define URL_GET_PROGRAM "curl -s -i --"
 #define URL_GET_BUF_SIZE 4096
 
 static int http_get_header_line(FILE *f, char *buf, size_t buf_size,
@@ -1347,16 +1347,22 @@ static JSValue js_std_urlGet(JSContext *ctx, JSValueConst this_val,
     }
     
     js_std_dbuf_init(ctx, &cmd_buf);
-    dbuf_printf(&cmd_buf, "%s ''", URL_GET_PROGRAM);
+    dbuf_printf(&cmd_buf, "%s '", URL_GET_PROGRAM);
     len = strlen(url);
     for(i = 0; i < len; i++) {
-        c = url[i];
-        if (c == '\'' || c == '\\')
+        switch (c = url[i]) {
+        case '\'':
+            dbuf_putstr(&cmd_buf, "'\\''");
+            break;
+        case '[': case ']': case '{': case '}': case '\\':
             dbuf_putc(&cmd_buf, '\\');
-        dbuf_putc(&cmd_buf, c);
+            /* FALLTHROUGH */
+        default:
+            dbuf_putc(&cmd_buf, c);
+        }
     }
     JS_FreeCString(ctx, url);
-    dbuf_putstr(&cmd_buf, "''");
+    dbuf_putstr(&cmd_buf, "'");
     dbuf_putc(&cmd_buf, '\0');
     if (dbuf_error(&cmd_buf)) {
         dbuf_free(&cmd_buf);


### PR DESCRIPTION
This corrects the basically non-functional escaping scheme. An `--` argument is added to prevent misinterpreting an initial `-` as an option character. Curly and square brackets (and backslashes) are additionally escaped to avoid triggering `curl`’s request batching syntax.

(Sorry for not using the mailing list, I am not currently able to.)