### PR TITLE
Optimize type error not a function and its name

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -16653,8 +16653,7 @@ static JSValue JS_CallInternal(JSContext *caller_ctx, JSValueConst func_obj,
                     if(opcode == OP_call0) {
                         pc -= 6;
                         if(*pc == OP_get_var) {
-                            pc++;
-                            JS_ThrowTypeErrorNotAFunction(ctx, get_u32(pc));
+                            JS_ThrowTypeErrorNotAFunction(ctx, get_u32(++pc));
                             goto exception;
                         }
                     }

--- a/quickjs.c
+++ b/quickjs.c
@@ -16647,7 +16647,7 @@ static JSValue JS_CallInternal(JSContext *caller_ctx, JSValueConst func_obj,
                 call_argv = sp - call_argc;
                 sf->cur_pc = pc;
                 JSValue fun_obj = call_argv[-1];
-                // When the call is not a function, an exception is thrown with the name.
+                // When the call is not a function, an exception is thrown and its name.
                 if (!JS_IsFunction(ctx, fun_obj)) {
                     // Currently, only call0 is handled.
                     if(opcode == OP_call0) {

--- a/quickjs.c
+++ b/quickjs.c
@@ -16658,7 +16658,7 @@ static JSValue JS_CallInternal(JSContext *caller_ctx, JSValueConst func_obj,
                         }
                     }
                 }
-                ret_val = JS_CallInternal(ctx, call_argv[-1], JS_UNDEFINED,
+                ret_val = JS_CallInternal(ctx, fun_obj, JS_UNDEFINED,
                                           JS_UNDEFINED, call_argc, call_argv, 0);
                 if (unlikely(JS_IsException(ret_val)))
                     goto exception;


### PR DESCRIPTION
In the following cases:

```javascript
var a;
a();

// Error
TypeError: not a function
    at <eval> (<evalScript>:1)
```

If it is in the compressed JS file, there may be only one line. Because there is no method name, it is not conducive to troubleshooting. Therefore, I have made an optimization here and displayed the name:

```javascript
var a;
a();

// Error and its name
TypeError: 'a' is not a function
    at <eval> (<evalScript>:1)
```

The reason for pull request is more to provide a solution to those who encounter the same problem. Sorry for any inconveniences caused :)
