### PR TITLE
[make] Fix packaging-related issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ CONFIG_LTO=y
 #CONFIG_COSMO=y
 
 # installation directory
-prefix=/usr/local
+PREFIX ?= /usr/local
 
 # use the gprof profiler
 #CONFIG_PROFILE=y
@@ -56,20 +56,20 @@ endif
 
 ifdef CONFIG_WIN32
   ifdef CONFIG_M32
-    CROSS_PREFIX=i686-w64-mingw32-
+    CROSS_PREFIX?=i686-w64-mingw32-
   else
-    CROSS_PREFIX=x86_64-w64-mingw32-
+    CROSS_PREFIX?=x86_64-w64-mingw32-
   endif
   EXE=.exe
 else
-  CROSS_PREFIX=
+  CROSS_PREFIX?=
   EXE=
 endif
 
 ifdef CONFIG_CLANG
   HOST_CC=clang
   CC=$(CROSS_PREFIX)clang
-  CFLAGS=-g -Wall -MMD -MF $(OBJDIR)/$(@F).d
+  CFLAGS+=-g -Wall -MMD -MF $(OBJDIR)/$(@F).d
   CFLAGS += -Wextra
   CFLAGS += -Wno-sign-compare
   CFLAGS += -Wno-missing-field-initializers
@@ -98,7 +98,7 @@ else ifdef CONFIG_COSMO
 else
   HOST_CC=gcc
   CC=$(CROSS_PREFIX)gcc
-  CFLAGS=-g -Wall -MMD -MF $(OBJDIR)/$(@F).d
+  CFLAGS+=-g -Wall -MMD -MF $(OBJDIR)/$(@F).d
   CFLAGS += -Wno-array-bounds -Wno-format-truncation
   ifdef CONFIG_LTO
     AR=$(CROSS_PREFIX)gcc-ar
@@ -125,9 +125,9 @@ CFLAGS_SMALL=$(CFLAGS) -Os
 CFLAGS_OPT=$(CFLAGS) -O2
 CFLAGS_NOLTO:=$(CFLAGS_OPT)
 ifdef CONFIG_COSMO
-LDFLAGS=-s # better to strip by default
+LDFLAGS+=-s # better to strip by default
 else
-LDFLAGS=-g
+LDFLAGS+=-g
 endif
 ifdef CONFIG_LTO
 CFLAGS_SMALL+=-flto
@@ -221,11 +221,11 @@ $(QJSC): $(OBJDIR)/qjsc.host.o \
 
 endif #CROSS_PREFIX
 
-QJSC_DEFINES:=-DCONFIG_CC=\"$(QJSC_CC)\" -DCONFIG_PREFIX=\"$(prefix)\"
+QJSC_DEFINES:=-DCONFIG_CC=\"$(QJSC_CC)\" -DCONFIG_PREFIX=\"$(PREFIX)\"
 ifdef CONFIG_LTO
 QJSC_DEFINES+=-DCONFIG_LTO
 endif
-QJSC_HOST_DEFINES:=-DCONFIG_CC=\"$(HOST_CC)\" -DCONFIG_PREFIX=\"$(prefix)\"
+QJSC_HOST_DEFINES:=-DCONFIG_CC=\"$(HOST_CC)\" -DCONFIG_PREFIX=\"$(PREFIX)\"
 
 $(OBJDIR)/qjsc.o: CFLAGS+=$(QJSC_DEFINES)
 $(OBJDIR)/qjsc.host.o: CFLAGS+=$(QJSC_HOST_DEFINES)
@@ -318,17 +318,17 @@ clean:
 	rm -rf run-test262-debug run-test262-32
 
 install: all
-	mkdir -p "$(DESTDIR)$(prefix)/bin"
+	mkdir -p "$(DESTDIR)$(PREFIX)/bin"
 	$(STRIP) qjs qjsc
-	install -m755 qjs qjsc "$(DESTDIR)$(prefix)/bin"
-	ln -sf qjs "$(DESTDIR)$(prefix)/bin/qjscalc"
-	mkdir -p "$(DESTDIR)$(prefix)/lib/quickjs"
-	install -m644 libquickjs.a "$(DESTDIR)$(prefix)/lib/quickjs"
+	install -m755 qjs qjsc "$(DESTDIR)$(PREFIX)/bin"
+	ln -sf qjs "$(DESTDIR)$(PREFIX)/bin/qjscalc"
+	mkdir -p "$(DESTDIR)$(PREFIX)/lib/quickjs"
+	install -m644 libquickjs.a "$(DESTDIR)$(PREFIX)/lib/quickjs"
 ifdef CONFIG_LTO
-	install -m644 libquickjs.lto.a "$(DESTDIR)$(prefix)/lib/quickjs"
+	install -m644 libquickjs.lto.a "$(DESTDIR)$(PREFIX)/lib/quickjs"
 endif
-	mkdir -p "$(DESTDIR)$(prefix)/include/quickjs"
-	install -m644 quickjs.h quickjs-libc.h "$(DESTDIR)$(prefix)/include/quickjs"
+	mkdir -p "$(DESTDIR)$(PREFIX)/include/quickjs"
+	install -m644 quickjs.h quickjs-libc.h "$(DESTDIR)$(PREFIX)/include/quickjs"
 
 ###############################################################################
 # examples


### PR DESCRIPTION
For packaging QuickJS, it is helpful to derive build flags from the environment. This helps to inject additional build flags, change build and installation prefixes, etc. The following flags have been altered to respect their environment variable counterparts:

-   PREFIX (renamed from `prefix`)
-   CROSS_PREFIX
-   CFLAGS, LDFLAGS