### PR TITLE
Fix locale-aware representation of hours in Date class

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -48203,7 +48203,7 @@ static JSValue get_date_string(JSContext *ctx, JSValueConst this_val,
             break;
         case 3:
             pos += snprintf(buf + pos, sizeof(buf) - pos,
-                            "%02d:%02d:%02d %cM", (h + 1) % 12 - 1, m, s,
+                            "%02d:%02d:%02d %cM", (h + 11) % 12 + 1, m, s,
                             (h < 12) ? 'A' : 'P');
             break;
         }


### PR DESCRIPTION
This change fixes `Date.toLocaleString()` when the hour value is 11 or 12.

Example:
```
var dt = new Date('2023-03-10 11:23:05.123 +13:00 Pacific/Auckland');
console.log(dt.toLocaleString());
dt = new Date('2023-03-10 12:23:05.123 +13:00 Pacific/Auckland');
console.log(dt.toLocaleString());
```

Expected output:
```
03/10/2023, 11:23:05 AM
03/10/2023, 12:23:05 PM
```

Actual output:
```
03/10/2023, -1:23:05 AM
03/10/2023, 00:23:05 PM
```