### PR TITLE
Fix stack overflow in CVE-2023-31922

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -45243,6 +45243,12 @@ static int js_proxy_isArray(JSContext *ctx, JSValueConst obj)
     JSProxyData *s = JS_GetOpaque(obj, JS_CLASS_PROXY);
     if (!s)
         return FALSE;
+
+    if (js_check_stack_overflow(ctx->rt, 0)) {
+        JS_ThrowStackOverflow(ctx);
+        return -1;
+    }
+
     if (s->is_revoked) {
         JS_ThrowTypeErrorRevokedProxy(ctx);
         return -1;


### PR DESCRIPTION
`isArray` and proxy `isArray` can call each other indefinitely in a mutually recursive loop.

Add a stack overflow check in the `js_proxy_isArray` function before calling `JS_isArray(ctx, s->target)`.

With ASAN and the poc.js from issue #178:

```
./qjs ./poc.js
InternalError: stack overflow
  at isArray (native)
  at <eval> (./poc.js:4)
```

Fix: https://github.com/bellard/quickjs/issues/178