### PR TITLE
Add an option to output profiling/coverage info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,10 @@ else
 LDEXPORT=-rdynamic
 endif
 
+ifdef CONFIG_PROFILE_CALLS
+CFLAGS+=-DCONFIG_PROFILE_CALLS
+endif
+
 PROGS=qjs$(EXE) qjsc$(EXE) run-test262
 ifneq ($(CROSS_PREFIX),)
 QJSC_CC=gcc

--- a/qjs.c
+++ b/qjs.c
@@ -297,6 +297,9 @@ void help(void)
 #endif
            "-T  --trace        trace memory allocation\n"
            "-d  --dump         dump the memory usage stats\n"
+#ifdef CONFIG_PROFILE_CALLS
+           "-p  --profile      dump the profiling stats\n"
+#endif
            "    --memory-limit n       limit the memory usage to 'n' bytes\n"
            "    --stack-size n         limit the stack size to 'n' bytes\n"
            "    --unhandled-rejection  dump unhandled promise rejections\n"
@@ -314,6 +317,9 @@ int main(int argc, char **argv)
     int interactive = 0;
     int dump_memory = 0;
     int trace_memory = 0;
+#ifdef CONFIG_PROFILE_CALLS
+    int profile_calls = 0;
+#endif
     int empty_run = 0;
     int module = -1;
     int load_std = 0;
@@ -407,6 +413,12 @@ int main(int argc, char **argv)
                 trace_memory++;
                 continue;
             }
+#ifdef CONFIG_PROFILE_CALLS
+            if (opt == 'p' || !strcmp(longopt, "profile")) {
+                ++profile_calls;
+                continue;
+            }
+#endif
             if (!strcmp(longopt, "std")) {
                 load_std = 1;
                 continue;
@@ -467,6 +479,10 @@ int main(int argc, char **argv)
         fprintf(stderr, "qjs: cannot allocate JS runtime\n");
         exit(2);
     }
+#ifdef CONFIG_PROFILE_CALLS
+    if(profile_calls)
+        JS_EnableProfileCalls(rt, profile_calls);
+#endif
     if (memory_limit != 0)
         JS_SetMemoryLimit(rt, memory_limit);
     if (stack_size != 0)

--- a/quickjs.h
+++ b/quickjs.h
@@ -346,6 +346,10 @@ typedef void JS_MarkFunc(JSRuntime *rt, JSGCObjectHeader *gp);
 void JS_MarkValue(JSRuntime *rt, JSValueConst val, JS_MarkFunc *mark_func);
 void JS_RunGC(JSRuntime *rt);
 JS_BOOL JS_IsLiveObject(JSRuntime *rt, JSValueConst obj);
+#ifdef CONFIG_PROFILE_CALLS
+void JS_EnableProfileCalls(JSRuntime *rt, uint32_t enable);
+#endif
+
 
 JSContext *JS_NewContext(JSRuntime *rt);
 void JS_FreeContext(JSContext *s);


### PR DESCRIPTION
Add an option to output profiling/coverage info (basically function calls count and clock_t time spent).

There is an option to define how many samples to use with the definition of compile time macro "PROFILE_CALLS_SAMPLE" the default value is 10. The code is guarded by a compile time macro "CONFIG_PROFILE_CALLS", to build execute "make CONFIG_PROFILE_CALLS=1". When using the added option "-p" we can repeat it up to 3 times:
- "-p" -> Only update calls count and omit functions with 0 calls
- "-p -p" -> Update calls count and sampled time_spent  and omit functions with 0 calls
- "-p -p -p" -> Like the above but showing functions with 0 calls. The output format:
=[ code_line call_count acumulated_time_spent average_time_spent function_name ] [454	2	1	6	xfillArr]