### PR TITLE
Add CI.

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -1,0 +1,54 @@
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+  pull_request:
+
+jobs:
+  linux:
+    name: Linux (Ubuntu)
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build
+      run: make
+    - name: Run built-in tests
+      run: make test
+
+  mac:
+    name: macOS
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build
+      run: make
+    - name: Run built-in tests
+      run: make test
+
+  qemu-alpine:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - i386
+          - arm32v6
+          - arm32v7
+          - arm64v8
+          - s390x
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+            submodules: recursive
+      - name: Get qemu
+        run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+      - name: Run tests on ${{ matrix.platform }}
+        run: docker run --rm --interactive --mount type=bind,source=$(pwd),target=/host ${{ matrix.platform }}/alpine sh -c "apk add git patch make gcc libc-dev && cd /host && make test"

--- a/tests/test_std.js
+++ b/tests/test_std.js
@@ -144,7 +144,9 @@ function test_os()
 {
     var fd, fpath, fname, fdir, buf, buf2, i, files, err, fdate, st, link_path;
 
-    assert(os.isatty(0));
+    const stdinIsTTY = !os.exec(["/bin/sh", "-c", "test -t 0"], { usePath: false });
+
+    assert(os.isatty(0), stdinIsTTY, `isatty(STDIN)`);
 
     fdir = "test_tmp_dir";
     fname = "tmp_file.txt";
@@ -253,10 +255,11 @@ function test_os_exec()
 
     pid = os.exec(["cat"], { block: false } );
     assert(pid >= 0);
-    os.kill(pid, os.SIGQUIT);
+    os.kill(pid, os.SIGTERM);
     [ret, status] = os.waitpid(pid, 0);
     assert(ret, pid);
-    assert(status & 0x7f, os.SIGQUIT);
+    assert(status !== 0, true, `expect nonzero exit code (got ${status})`);
+    assert(status & 0x7f, os.SIGTERM);
 }
 
 function test_timer()


### PR DESCRIPTION
This switches the exec test to SIGTERM rather than SIGQUIT since the latter didn’t seem to work in QEMU, and the distinction doesn’t really matter for this test.

This also makes the isatty() check smarter by checking whether STDIN is, in fact, a terminal.