### PR TITLE
Fix build: use LRE_BOOL in libunicode.h

### DIFF
--- a/libunicode.h
+++ b/libunicode.h
@@ -41,7 +41,7 @@ typedef enum {
 } UnicodeNormalizationEnum;
 
 int lre_case_conv(uint32_t *res, uint32_t c, int conv_type);
-int lre_canonicalize(uint32_t c, BOOL is_unicode);
+int lre_canonicalize(uint32_t c, LRE_BOOL is_unicode);
 LRE_BOOL lre_is_cased(uint32_t c);
 LRE_BOOL lre_is_case_ignorable(uint32_t c);
 
@@ -102,7 +102,7 @@ int cr_op(CharRange *cr, const uint32_t *a_pt, int a_len,
 
 int cr_invert(CharRange *cr);
 
-int cr_regexp_canonicalize(CharRange *cr, BOOL is_unicode);
+int cr_regexp_canonicalize(CharRange *cr, LRE_BOOL is_unicode);
 
 #ifdef CONFIG_ALL_UNICODE
 


### PR DESCRIPTION
This is currently blocking https://github.com/google/oss-fuzz/pull/11641 that sets max stack size for fuzzers as a part of the OSS-Fuzz project