### PR TITLE
Expose `JS_SetUncatchableError()`

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -1275,7 +1275,6 @@ static JSValue js_module_ns_autoinit(JSContext *ctx, JSObject *p, JSAtom atom,
                                  void *opaque);
 static JSValue JS_InstantiateFunctionListItem2(JSContext *ctx, JSObject *p,
                                                JSAtom atom, void *opaque);
-void JS_SetUncatchableError(JSContext *ctx, JSValueConst val, BOOL flag);
 static JSValue js_object_groupBy(JSContext *ctx, JSValueConst this_val,
                                  int argc, JSValueConst *argv, int is_map);
 

--- a/quickjs.h
+++ b/quickjs.h
@@ -634,6 +634,7 @@ static inline JS_BOOL JS_IsObject(JSValueConst v)
 JSValue JS_Throw(JSContext *ctx, JSValue obj);
 JSValue JS_GetException(JSContext *ctx);
 JS_BOOL JS_IsError(JSContext *ctx, JSValueConst val);
+void JS_SetUncatchableError(JSContext *ctx, JSValueConst val, JS_BOOL flag);
 void JS_ResetUncatchableError(JSContext *ctx);
 JSValue JS_NewError(JSContext *ctx);
 JSValue __js_printf_like(2, 3) JS_ThrowSyntaxError(JSContext *ctx, const char *fmt, ...);


### PR DESCRIPTION
We're using this as a means to terminate JavaScript execution: https://github.com/holepunchto/libqjs/blob/995be8e34e77eca38008e6bab6b403de577f1f1c/src/qjs.c#L4812-L4825