### PR TITLE
Improve class parser

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -22381,7 +22381,7 @@ static int __exception js_parse_property_name(JSParseState *s,
                 goto fail1;
             if (s->token.val == ':' || s->token.val == ',' ||
                 s->token.val == '}' || s->token.val == '(' ||
-                s->token.val == '=' ) {
+                s->token.val == '=') {
                 is_non_reserved_ident = TRUE;
                 goto ident_found;
             }
@@ -22397,7 +22397,8 @@ static int __exception js_parse_property_name(JSParseState *s,
             if (next_token(s))
                 goto fail1;
             if (s->token.val == ':' || s->token.val == ',' ||
-                s->token.val == '}' || s->token.val == '(') {
+                s->token.val == '}' || s->token.val == '(' ||
+                s->token.val == '=') {
                 is_non_reserved_ident = TRUE;
                 goto ident_found;
             }
@@ -23081,7 +23082,12 @@ static __exception int js_parse_class(JSParseState *s, BOOL is_class_expr,
                 goto fail;
             continue;
         }
-        is_static = (s->token.val == TOK_STATIC);
+        is_static = FALSE;
+        if (s->token.val == TOK_STATIC) {
+            int next = peek_token(s, TRUE);
+            if (!(next == ';' || next == '}' || next == '(' || next == '='))
+                is_static = TRUE;
+        }
         prop_type = -1;
         if (is_static) {
             if (next_token(s))

--- a/tests/test_language.js
+++ b/tests/test_language.js
@@ -335,11 +335,13 @@ function test_class()
     assert(S.x === 42);
     assert(S.y === 42);
     assert(S.z === 42);
-    
+
     class P {
-      get = () => "123"
+        get = () => "123";
+        static() { return 42; }
     }
     assert(new P().get() === "123");
+    assert(new P().static() === 42);
 };
 
 function test_template()


### PR DESCRIPTION
- accept `class P { async = 1 }}`
- accept `class P { static = 1 }}` etc.
- Fixes #261