### PR TITLE
Remove new lines in function constructor

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -38397,7 +38397,7 @@ static JSValue js_function_constructor(JSContext *ctx, JSValueConst new_target,
         if (string_buffer_concat_value(b, argv[i]))
             goto fail;
     }
-    string_buffer_puts8(b, "\n) {\n");
+    string_buffer_puts8(b, ") {");
     if (n >= 0) {
         if (string_buffer_concat_value(b, argv[n]))
             goto fail;


### PR DESCRIPTION
I have noticed that exceptions raised from functions created by "new Function" have "invalid" line numbers in stacktrace.

For example:
`(new Function("throw new Exception('abc');"))()`
reports `(<input>:3)`

By removing two additional new line characters, exception reports line numbers matching code provided to Function constructor.