### PR TITLE
Add CONFIG_NO_WORKER Makefile option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,9 @@ ifeq ($(shell $(CC) -o /dev/null compat/test-closefrom.c 2>/dev/null && echo 1),
 DEFINES+=-DHAVE_CLOSEFROM
 endif
 endif
+ifdef CONFIG_NO_WORKER
+DEFINES+=-DCONFIG_NO_WORKER
+endif
 
 CFLAGS+=$(DEFINES)
 CFLAGS_DEBUG=$(CFLAGS) -O0

--- a/quickjs-libc.c
+++ b/quickjs-libc.c
@@ -64,7 +64,7 @@ typedef sig_t sighandler_t;
 
 #endif
 
-#if !defined(_WIN32)
+#if !defined(_WIN32) && !defined(CONFIG_NO_WORKER)
 /* enable the os.Worker API. IT relies on POSIX threads */
 #define USE_WORKER
 #endif

--- a/quickjs.c
+++ b/quickjs.c
@@ -68,7 +68,7 @@
 
 /* define to include Atomics.* operations which depend on the OS
    threads */
-#if !defined(EMSCRIPTEN)
+#if !defined(EMSCRIPTEN) && !defined(CONFIG_NO_WORKER)
 #define CONFIG_ATOMICS
 #endif
 


### PR DESCRIPTION
This option eliminates the dependency on the pthread library. This mode is already toggled on _WIN32 and/or when EMSCRIPTEN is detected, here we just allow the user to toggle it at will at the top level.

This slightly reduces the code size as well, and may allow compiling this library in some embedded contexts where pthread is not available or is broken.