### PR TITLE
Fix GC leak in `js_proxy_get()`

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -46151,8 +46151,10 @@ static JSValue js_proxy_get(JSContext *ctx, JSValueConst obj, JSAtom atom,
     if (JS_IsException(ret))
         return JS_EXCEPTION;
     res = JS_GetOwnPropertyInternal(ctx, &desc, JS_VALUE_GET_OBJ(s->target), atom);
-    if (res < 0)
+    if (res < 0) {
+        JS_FreeValue(ctx, ret);
         return JS_EXCEPTION;
+    }
     if (res) {
         if ((desc.flags & (JS_PROP_GETSET | JS_PROP_CONFIGURABLE | JS_PROP_WRITABLE)) == 0) {
             if (!js_same_value(ctx, desc.value, ret)) {


### PR DESCRIPTION
Simplified test case to reproduce:

```js
function a() {
    return {};
}
var d = new Date();
var o1 = new Proxy(d, {get: 0});
var o2 = new Proxy(d, o1);
var o = new Proxy(o2, {get: a})

o.a
```