### PR TITLE
GNU/Hurd build fixes

### DIFF
--- a/qjs.c
+++ b/qjs.c
@@ -34,7 +34,7 @@
 #include <time.h>
 #if defined(__APPLE__)
 #include <malloc/malloc.h>
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__GLIBC__)
 #include <malloc.h>
 #elif defined(__FreeBSD__)
 #include <malloc_np.h>
@@ -151,7 +151,7 @@ static size_t js_trace_malloc_usable_size(const void *ptr)
     return _msize((void *)ptr);
 #elif defined(EMSCRIPTEN)
     return 0;
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__GLIBC__)
     return malloc_usable_size((void *)ptr);
 #else
     /* change this to `return 0;` if compilation fails */

--- a/quickjs-libc.c
+++ b/quickjs-libc.c
@@ -1090,7 +1090,7 @@ static JSValue js_std_file_tell(JSContext *ctx, JSValueConst this_val,
     int64_t pos;
     if (!f)
         return JS_EXCEPTION;
-#if defined(__linux__)
+#if defined(__linux__) || defined(__GLIBC__)
     pos = ftello(f);
 #else
     pos = ftell(f);
@@ -1113,7 +1113,7 @@ static JSValue js_std_file_seek(JSContext *ctx, JSValueConst this_val,
         return JS_EXCEPTION;
     if (JS_ToInt32(ctx, &whence, argv[1]))
         return JS_EXCEPTION;
-#if defined(__linux__)
+#if defined(__linux__) || defined(__GLIBC__)
     ret = fseeko(f, pos, whence);
 #else
     ret = fseek(f, pos, whence);

--- a/quickjs-libc.c
+++ b/quickjs-libc.c
@@ -78,6 +78,10 @@ typedef sig_t sighandler_t;
 #include "list.h"
 #include "quickjs-libc.h"
 
+#if !defined(PATH_MAX)
+#define PATH_MAX 4096
+#endif
+
 /* TODO:
    - add socket calls
 */

--- a/quickjs.c
+++ b/quickjs.c
@@ -34,7 +34,7 @@
 #include <math.h>
 #if defined(__APPLE__)
 #include <malloc/malloc.h>
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__GLIBC__)
 #include <malloc.h>
 #elif defined(__FreeBSD__)
 #include <malloc_np.h>
@@ -1708,7 +1708,7 @@ static size_t js_def_malloc_usable_size(const void *ptr)
     return _msize((void *)ptr);
 #elif defined(EMSCRIPTEN)
     return 0;
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__GLIBC__)
     return malloc_usable_size((void *)ptr);
 #else
     /* change this to `return 0;` if compilation fails */


### PR DESCRIPTION
This PR fixes the build of quickjs on GNU/Hurd:
- use `malloc_usable_size()` when using glibc
- use `ftello()` & `fseeko()` when using glibc (they could be used more, I took a conservative approach)
- provide a fallback `PATH_MAX` if not available

See the messages of the various commits for longer explanations.