### PR TITLE
Fix termination in Worker test

### DIFF
--- a/tests/test_worker_module.js
+++ b/tests/test_worker_module.js
@@ -10,7 +10,7 @@ function handle_msg(e) {
     switch(ev.type) {
     case "abort":
         parent.postMessage({ type: "done" });
-        parent.onMessage = null; /* terminate the worker */
+        parent.onmessage = null; /* terminate the worker */
         break;
     case "sab":
         /* modify the SharedArrayBuffer */


### PR DESCRIPTION
Function names are case sensitive, `onMessage` is not the same as `onmessage`.

Related to #98