### PR TITLE
Add WeakRef Implementation

### DIFF
--- a/TODO
+++ b/TODO
@@ -47,7 +47,6 @@ Optimization ideas:
 - add implicit numeric strings for Uint32 numbers?
 - optimize `s += a + b`, `s += a.b` and similar simple expressions
 - ensure string canonical representation and optimise comparisons and hashes?
-- remove JSObject.first_weak_ref, use bit+context based hashed array for weak references
 - property access optimization on the global object, functions,
   prototypes and special non extensible objects.
 - create object literals with the correct length by backpatching length argument

--- a/doc/quickjs.texi
+++ b/doc/quickjs.texi
@@ -281,9 +281,7 @@ The following features are not supported yet:
 
 @item Tail calls@footnote{We believe the current specification of tails calls is too complicated and presents limited practical interests.}
 
-@item WeakRef and FinalizationRegistry objects
-
-@item Symbols as WeakMap keys
+@item FinalizationRegistry objects
 
 @end itemize
 

--- a/qjsc.c
+++ b/qjsc.c
@@ -77,6 +77,7 @@ static const FeatureEntry feature_list[] = {
 #define FE_MODULE_LOADER 9
     { "module-loader", NULL },
     { "bigint", "BigInt" },
+    { "weakref", "WeakRef" },
 };
 
 void namelist_add(namelist_t *lp, const char *name, const char *short_name,

--- a/quickjs-atom.h
+++ b/quickjs-atom.h
@@ -269,5 +269,6 @@ DEF(Symbol_asyncIterator, "Symbol.asyncIterator")
 #ifdef CONFIG_BIGNUM
 DEF(Symbol_operatorSet, "Symbol.operatorSet")
 #endif
+DEF(WeakRef, "WeakRef")
 
 #endif /* DEF */

--- a/quickjs.h
+++ b/quickjs.h
@@ -376,6 +376,7 @@ void JS_AddIntrinsicPromise(JSContext *ctx);
 void JS_AddIntrinsicBigInt(JSContext *ctx);
 void JS_AddIntrinsicBigFloat(JSContext *ctx);
 void JS_AddIntrinsicBigDecimal(JSContext *ctx);
+void JS_AddIntrinsicWeakRef(JSContext *ctx);
 /* enable operator overloading */
 void JS_AddIntrinsicOperators(JSContext *ctx);
 /* enable "use math" */
@@ -1076,6 +1077,10 @@ int JS_SetModuleExport(JSContext *ctx, JSModuleDef *m, const char *export_name,
                        JSValue val);
 int JS_SetModuleExportList(JSContext *ctx, JSModuleDef *m,
                            const JSCFunctionListEntry *tab, int len);
+
+/* WeakRef support */
+JSValue JS_NewWeakRef(JSContext *ctx, JSValueConst target);
+JSValue JS_DerefWeakRef(JSContext *ctx, JSValueConst weakref);
 
 #undef js_unlikely
 #undef js_force_inline

--- a/test262.conf
+++ b/test262.conf
@@ -204,7 +204,7 @@ Uint32Array
 Uint8Array
 Uint8ClampedArray
 WeakMap
-WeakRef=skip
+WeakRef
 WeakSet
 well-formed-json-stringify
 

--- a/tests/microbench.js
+++ b/tests/microbench.js
@@ -1114,6 +1114,33 @@ function string_to_float(n)
     return n;
 }
 
+function weakref(n)
+{
+    var objs = new Array(n);
+    var weak1 = new Array(n);
+    var weak2 = new Array(n);
+    for (var i = 0; i < n; i++) {
+        objs[i] = { index: i };
+        weak1[i] = new WeakRef(objs[i]); /* init object hash table*/
+        weak2[i] = new WeakRef(objs[i]); /* find hsh table then add */
+    }
+    for (var i = 0; i < n; i++) {
+        weak1[i].deref();
+        weak2[i].deref();
+    }
+    for (var i = 0; i < n / 2; i++) {
+        objs[i] = undefined; /* release weak and hash table */
+    }
+    for (var i = 0; i < n; i++) {
+        weak1[i].deref();
+        weak2[i].deref();
+    }
+    weak1 = undefined;
+    weak2 = undefined;
+    objs = undefined;
+    return n * 3;
+}
+
 function load_result(filename)
 {
     var has_filename = filename;
@@ -1236,6 +1263,7 @@ function main(argc, argv, g)
         float_to_string,
         string_to_int,
         string_to_float,
+        weakref,
     ];
     var tests = [];
     var i, j, n, f, name, found;

--- a/tests/test_builtin.js
+++ b/tests/test_builtin.js
@@ -779,6 +779,59 @@ function test_weak_map()
         tab[i][0] = null; /* should remove the object from the WeakMap too */
     }
     /* the WeakMap should be empty here */
+
+    // test symbol as key
+    var symbol_key = Symbol("key");
+    a = new WeakMap();
+    a.set(symbol_key, "hello");
+    assert(a.has(symbol_key), true);
+    assert(a.get(symbol_key), "hello");
+
+    symbol_key = undefined;
+    assert(a.has(symbol_key), false);
+    assert(a.get(symbol_key), undefined);
+}
+
+function test_weak_ref()
+{
+    var obj = {};
+    var ref = new WeakRef(obj);
+    var ref2 = new WeakRef(obj);
+
+    assert(ref.deref(), obj);
+    assert(ref2.deref(), obj);
+
+    obj = undefined;
+    /* weak ref should be released */
+    assert(ref.deref(), undefined);
+    assert(ref2.deref(), undefined);
+
+    // symbol
+    var sym = Symbol("sym")
+    var ref3 = new WeakRef(sym);
+    assert(ref3.deref(), sym);
+    new WeakRef(Symbol.hasInstance);
+
+    sym = undefined;
+    assert(ref3.deref(), undefined);
+
+    function should_fail(block) {
+        try {
+            block()
+        } catch (e) {
+            return
+        }
+        throw_error("weak ref should throw exception, but it not");
+    }
+
+    should_fail(() => new WeakRef("string"));
+    should_fail(() => new WeakRef(/* number */0));
+    should_fail(() => new WeakRef(/* registered symbol */ Symbol.for("test")));
+
+    /* cyclic ref */
+    obj = {};
+    ref = new WeakRef(obj);
+    obj["x"] = ref;
 }
 
 function test_generator()
@@ -855,4 +908,5 @@ test_regexp();
 test_symbol();
 test_map();
 test_weak_map();
+test_weak_ref();
 test_generator();


### PR DESCRIPTION
> Description is continuously edited according to discussions.

This PR did several related things.

#### 1. Refactor JSObject weak reference list to support different kinds of weak reference
Changed `JSObject.u.first_weak_ref`, which was designed for WeakMap/WeakSet only. Also added weak reference support to `JSString` (ie. Atom/Symbol ).

It makes it easy to add `WeakRef` implementation. (And possibly `FinalizationRegistry` which is [almost done](https://github.com/LanderlYoung/quickjs/pull/2), will create another PR after this one ).

#### 2. Add WeakRef implementation

Added standard WeakRef implementation together with test cases.
Referenced to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef

#### 3. Support Symbol as WeakMap key
As a nice-to-have thing, also closed a TODO item in the doc.

https://github.com/bellard/quickjs/blob/6e2e68fd0896957f92eb6c242a2e048c1ef3cae0/doc/quickjs.texi#L286

#### 4. Change JSObject.weak_ref_list to use a bit and external hash table. 

Save memory for each JSObject (8 bytes on 64-bit platform, 4 bytes on 32-bit platform), while still maintaining good performance. 

**Performance test result**
<details>
  <summary>Test Code</summary>

```JavaScript
var size = 1000 * 1000;
var start = Date.now();
var objs = new Array(size);
var weak1 = new Array(size);
var weak2 = new Array(size);
var newObject = time (() => {
    for (var i = 0; i < size; i++) {
	objs[i] = { index: i };
    }
});
var newWeak1 = time(() => {
    for (var i = 0; i < size; i++) {
	weak1[i] = new WeakRef(objs[i]);
    }
});
var newWeak2 = time(() => {
    for (var i = 0; i < size; i++) {
	weak2[i] = new WeakRef(objs[i]);
    }
});
var deref1 = time(() => {
    for (var i = 0; i < size; i++) {
	assert(weak1[i].deref(), objs[i]);
	assert(weak2[i].deref(), objs[i]);
    }
});
var free1 = time(() => {
    for (var i = 0; i < size / 2; i++) {
	objs[i] = undefined;
    }
});
var deref2 = time(() => {
    for (var i = 0; i < size / 2; i++) {
	assert(weak1[i].deref(), undefined);
	assert(weak2[i].deref(), undefined);
    }
});
var free2 = time(() => {
    weak1 = undefined;
    weak2 = undefined;
    objs = undefined;
});
var total = Date.now() - start;
```
</details>

Test Result:
(tested on Macbook Pro with M2 Pro chip, with 1 million iterations, time-unit is millisecond)

|  code branch | newObject | newWeak1 | newWeak2 | deref1 | deref2 | free1 | free2 | total |
|  -- | -- | -- | -- | -- | -- | -- | -- | -- |
| pointer in JSObject | 169 | 107 | 195 | 1064 | 514 | 53| 131 | 2233 |
|  w/ hashmap | 64 | 255 | 324 | 1078 | 541 | 126| 181 | 2568 |

* pointer in JSObject: use `JSObject.first_weakref` pointer
* w/ hashmap: use a bit flag in `JSObject.has_weak_ref` and a `JSRuntime.weak_target_map`

1. New Object operations are faster, maybe due to a smaller object size.
2. New WeakRef operations are slower, but still acceptable.
3. Free object (that are weakly referenced) operations take slightly longer, less than 100 ns per operation.

Furthermore, theoretically, Objects/Symbols that are not weakly referenced have no performance impact.

Also added a generic (good performance) hash map implementation.
I tried to refactor JS Map based on that which resulted in a good performance improvement (https://github.com/LanderlYoung/quickjs/pull/4).


---

### Follow ups
other commits based on this PR:
1. https://github.com/LanderlYoung/quickjs/pull/4
2. https://github.com/LanderlYoung/quickjs/pull/2

Ready to open other PRs once this PR is merged.

---

> BTW: very happy to see QuickJs is accepting PRs
> I'm the author of [ScriptX](https://github.com/Tencent/ScriptX), and I added implementations of `WeaRef` with the help of `WeakMap` to meet project needs, while not fulfilling the ES standard.
> When I notice QuickJS is accepting PRs, I feel it's time to contribute some code!