### PR TITLE
Add a version of `JS_SetPropertyFunctionList()` that handles errors.

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -36998,6 +36998,25 @@ void JS_SetPropertyFunctionList(JSContext *ctx, JSValueConst obj,
     }
 }
 
+int JS_SetPropertyFunctionList2(JSContext *ctx, JSValueConst obj,
+                                const JSCFunctionListEntry *tab, int len)
+{
+    int i;
+
+    for (i = 0; i < len; i++) {
+        const JSCFunctionListEntry *e = &tab[i];
+        JSAtom atom = find_atom(ctx, e->name);
+        if (atom == JS_ATOM_NULL)
+            return -1;
+        if (JS_InstantiateFunctionListItem(ctx, obj, atom, e) < 0) {
+            JS_FreeAtom(ctx, atom);
+            return -1;
+        }
+        JS_FreeAtom(ctx, atom);
+    }
+    return 0;
+}
+
 int JS_AddModuleExportList(JSContext *ctx, JSModuleDef *m,
                            const JSCFunctionListEntry *tab, int len)
 {

--- a/quickjs.h
+++ b/quickjs.h
@@ -1060,6 +1060,10 @@ typedef struct JSCFunctionListEntry {
 void JS_SetPropertyFunctionList(JSContext *ctx, JSValueConst obj,
                                 const JSCFunctionListEntry *tab,
                                 int len);
+/* same as JS_SetPropertyFunctionList() returns -1 if exception, 0 if OK */
+int JS_SetPropertyFunctionList2(JSContext *ctx, JSValueConst obj,
+                                const JSCFunctionListEntry *tab,
+                                int len);
 
 /* C module definition */
 


### PR DESCRIPTION
Current status:
- Error handling in QuickJS is inconsistent across the codebase
- Some areas implement error checks, while others do not

This patch:
- Enhances error checking in JS_SetPropertyFunctionList()
- Aims to make QuickJS more reliable for long-running processes where uncaught errors can cause significant issues

Next steps:
- This is the first in a series of planned improvements
- Future patches will address other areas, including JS_AddIntrinsicBaseObjects() and related functions

Feedback is needed before proceeding with additional patches.