### PR TITLE
Fix SIGSEGV cause by WeakMap mem leak

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -5556,6 +5556,10 @@ void __JS_FreeValueRT(JSRuntime *rt, JSValue v)
                 if (rt->gc_phase == JS_GC_PHASE_NONE) {
                     free_zero_refcount(rt);
                 }
+            } else if (p->mark == 0) {
+                p->mark = 1;
+                list_del(&p->link);
+                list_add_tail(&p->link, &rt->tmp_obj_list);
             }
         }
         break;


### PR DESCRIPTION
Values in WeakMap may leaks and causes SIGSEGV error.

Reproduction example:
```
import * as std from 'std';
const weak1 = new WeakMap();
const weak2 = new WeakMap();
function createCyclicKey() {
    const parent = {};
    const child = {parent};
    parent.child = child;
    return child;
}
function testWeakMap() {
    const cyclicKey = createCyclicKey();
    const valueOfCyclicKey = {};
    weak1.set(cyclicKey, valueOfCyclicKey);
    weak2.set(valueOfCyclicKey, 1);
}
testWeakMap();
// Force to free cyclicKey.
std.gc();
// Here will cause sigsegv because [cyclicKey] and [valueOfCyclicKey] in [weak1] was free,
// but weak2's map record was not removed, and it's key refers [valueOfCyclicKey] which is free.
weak2.get({});
console.log("end");
```