### PR TITLE
Fix compiling with undefined to `bfdec_normalize_and_round`

### DIFF
--- a/libbf.c
+++ b/libbf.c
@@ -3104,11 +3104,14 @@ static int bf_atof_internal(bf_t *r, slimb_t *pexponent,
         if (exp_is_neg)
             expn = -expn;
     }
+#ifdef USE_BF_DEC
     if (is_dec) {
         a->expn = expn + int_len;
         a->sign = is_neg;
         ret = bfdec_normalize_and_round((bfdec_t *)a, prec, flags);
-    } else if (radix_bits) {
+    } else
+#endif
+    if (radix_bits) {
         /* XXX: may overflow */
         if (!is_bin_exp)
             expn *= radix_bits;


### PR DESCRIPTION
A compilation error occurs when without CONFIG_BIGNUM.
```text
quickjs/libbf.c:3110: error: undefined reference to 'bfdec_normalize_and_round'
```
Because there's no conditional handling here.
```c
/* enable it to check the multiplication result */
//#define USE_MUL_CHECK
#ifdef CONFIG_BIGNUM
/* enable it to use FFT/NTT multiplication */
#define USE_FFT_MUL
/* enable decimal floating point support */
#define USE_BF_DEC
#endif

static int bf_atof_internal(...){
    if (is_dec) {
        a->expn = expn + int_len;
        a->sign = is_neg;
        // we need to check if USE_BF_DEC is enabled.
        ret = bfdec_normalize_and_round((bfdec_t *)a, prec, flags);
    } else if (radix_bits) {
        ...
    }
   ...
```

I made a simple fix.
```c
#ifdef USE_BF_DEC
    if (is_dec) {
        a->expn = expn + int_len;
        a->sign = is_neg;
        ret = bfdec_normalize_and_round((bfdec_t *)a, prec, flags);
    } else
#endif
    if (radix_bits) {
```


Related issues:
https://github.com/bellard/quickjs/issues/241
https://github.com/bellard/quickjs/issues/326
