### PR TITLE
skip verification of class ID in JS_GetOpaque if class_id is 0

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -9847,7 +9847,7 @@ void *JS_GetOpaque(JSValueConst obj, JSClassID class_id)
     if (JS_VALUE_GET_TAG(obj) != JS_TAG_OBJECT)
         return NULL;
     p = JS_VALUE_GET_OBJ(obj);
-    if (p->class_id != class_id)
+    if (class_id && p->class_id != class_id)
         return NULL;
     return p->u.opaque;
 }


### PR DESCRIPTION
When using QuickJS from C++ I'd like to be able to get the opaque pointer back without necessarily knowing the class ID of the value.

As an example, I have a Parent class in C++ and multiple classes that extend it: Child1, Child2..., each with their own wrapping JS class. I want to create a JS function which can take any of these child classes, cast the opaque value to a `Parent *` and call methods on that.

Since 0 is not a valid class ID, using it to disable verification works well.