### PR TITLE
Fixing QuickJS bug with nan value handling, causing an infinite loop on Nintendo Switch

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -14097,20 +14097,25 @@ static no_inline int js_relational_slow(JSContext *ctx, JSValue *sp,
             } else {
                 d2 = JS_VALUE_GET_INT(op2);
             }
-            switch(op) {
-            case OP_lt:
-                res = (d1 < d2); /* if NaN return false */
-                break;
-            case OP_lte:
-                res = (d1 <= d2); /* if NaN return false */
-                break;
-            case OP_gt:
-                res = (d1 > d2); /* if NaN return false */
-                break;
-            default:
-            case OP_gte:
-                res = (d1 >= d2); /* if NaN return false */
-                break;
+
+            if (isnan(d1) || isnan(d2)) {
+                res = FALSE;
+            } else {
+                switch(op) {
+                case OP_lt:
+                    res = (d1 < d2);
+                    break;
+                case OP_lte:
+                    res = (d1 <= d2);
+                    break;
+                case OP_gt:
+                    res = (d1 > d2);
+                    break;
+                default:
+                case OP_gte:
+                    res = (d1 >= d2);
+                    break;
+                }
             }
         }
     }


### PR DESCRIPTION
The following scripting code was resulting in an infinite loop on Nintendo Switch in Minecraft with a custom behaviour pack:
![image](https://github.com/user-attachments/assets/8735d0c6-589d-4028-a679-981002d36755)

The first while loop condition assumes that once it goes beyond the end of the array bounds, it returns undefined (which it does), but then it also assumes that comparing UNDEFINED to a real value, returns false (which it should, but doesn't).

This internal code in quick js relies on the C++ 'feature' that comparing any value against nan, returns false:
![image](https://github.com/user-attachments/assets/99c23541-8d40-4232-aff9-c3c733f5fae8)

However, this is not a real constraint in the C++ stl/language.
https://stackoverflow.com/questions/38798791/nan-comparison-rule-in-c-c

It is a constraint for IEEE floating points, but C++ is not constrained to that requirement itself. So the result here is that on Switch sometimes it returns true for this evaluation, and in the scripting code above means we infinite loop.

Fix here is to deliberately and directly check for is nan and handle this case as false.