### PR TITLE
Fix undefined behavior

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -31215,7 +31215,7 @@ typedef struct CodeContext {
 
 #define M2(op1, op2)            ((op1) | ((op2) << 8))
 #define M3(op1, op2, op3)       ((op1) | ((op2) << 8) | ((op3) << 16))
-#define M4(op1, op2, op3, op4)  ((op1) | ((op2) << 8) | ((op3) << 16) | ((op4) << 24))
+#define M4(op1, op2, op3, op4)  ((op1) | ((op2) << 8) | ((op3) << 16) | (((uint32_t)op4) << 24))
 
 static BOOL code_match(CodeContext *s, int pos, ...)
 {


### PR DESCRIPTION
The current implementation of the M4 macro leads to a signed integer overflow error, which is undefined behavior:
> The result of `E1 << E2` is `E1 left-shifted E2` bit positions; vacated bits are filled with zeros. If E1 has
an unsigned type, the value of the result is E1 × 2E2, wrapped around. **If E1 has a signed type and
nonnegative value, and E1 × 2^E2 is representable in the result type, then that is the resulting value;
otherwise, the behavior is undefined**
(emphasis added)

