### PR TITLE
Implements Javascript profiling support.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,9 @@ PREFIX?=/usr/local
 
 # include the code for BigFloat/BigDecimal and math mode
 CONFIG_BIGNUM=y
+# Include code for profiling individual function calls.
+# qjs will produce a file compatible with chrome devtools and other tools.
+# CONFIG_PROFILE_CALLS=y
 
 OBJDIR=.obj
 
@@ -147,6 +150,9 @@ ifndef CONFIG_WIN32
 ifeq ($(shell $(CC) -o /dev/null compat/test-closefrom.c 2>/dev/null && echo 1),1)
 DEFINES+=-DHAVE_CLOSEFROM
 endif
+endif
+ifdef CONFIG_PROFILE_CALLS
+DEFINES+=-DCONFIG_PROFILE_CALLS
 endif
 
 CFLAGS+=$(DEFINES)

--- a/qjs.c
+++ b/qjs.c
@@ -289,12 +289,49 @@ void help(void)
 #endif
            "-T  --trace        trace memory allocation\n"
            "-d  --dump         dump the memory usage stats\n"
+#ifdef CONFIG_PROFILE_CALLS
+           "-p  --profile FILE dump the profiling stats to FILENAME in a format that can be open in chromium devtools\n"
+           "    --profile-sampling n collect function calls every 1/n times. Defaults to 1 (i.e. every call)\n"
+#endif
            "    --memory-limit n       limit the memory usage to 'n' bytes\n"
            "    --stack-size n         limit the stack size to 'n' bytes\n"
            "    --unhandled-rejection  dump unhandled promise rejections\n"
            "-q  --quit         just instantiate the interpreter and quit\n");
     exit(1);
 }
+
+#ifdef CONFIG_PROFILE_CALLS
+void profile_function_start(JSContext *ctx, JSAtom func, JSAtom filename, void *opaque) {
+    const char* func_str = JS_AtomToCString(ctx, func);
+    const char *func_str2 = func_str[0] ? func_str : "<anonymous>";
+    FILE *logfile = (FILE *)opaque;
+    // Format documented here:
+    // https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview?tab=t.0#heading=h.yr4qxyxotyw
+    fprintf(logfile, "{"
+            "\"name\": \"%s\","
+            "\"cat\": \"js\","
+            "\"ph\": \"B\","
+            "\"ts\": %ld,"
+            "\"pid\": 1,"
+            "\"tid\": 1"
+        "},\n", func_str2, clock());
+    JS_FreeCString(ctx, func_str);
+}
+void profile_function_end(JSContext *ctx, JSAtom func, JSAtom filename, void *opaque) {
+    const char* func_str = JS_AtomToCString(ctx, func);
+    const char *func_str2 = func_str[0] ? func_str : "<anonymous>";
+    FILE *logfile = (FILE *)opaque;
+    fprintf(logfile, "{"
+            "\"name\": \"%s\","
+            "\"cat\": \"js\","
+            "\"ph\": \"E\","
+            "\"ts\": %ld,"
+            "\"pid\": 1,"
+            "\"tid\": 1"
+        "},\n", func_str2, clock());
+    JS_FreeCString(ctx, func_str);
+}
+#endif
 
 int main(int argc, char **argv)
 {
@@ -306,6 +343,10 @@ int main(int argc, char **argv)
     int interactive = 0;
     int dump_memory = 0;
     int trace_memory = 0;
+#ifdef CONFIG_PROFILE_CALLS
+    FILE *profile_file = NULL;
+    uint32_t profile_sampling = 1;
+#endif
     int empty_run = 0;
     int module = -1;
     int load_std = 0;
@@ -399,6 +440,29 @@ int main(int argc, char **argv)
                 trace_memory++;
                 continue;
             }
+#ifdef CONFIG_PROFILE_CALLS
+            if (opt == 'p' || !strcmp(longopt, "profile")) {
+                if (*arg) {
+                    profile_file = fopen(arg, "w");
+                    break;
+                }
+                if (optind < argc) {
+                    profile_file = fopen(argv[optind++], "w");
+                    break;
+                }
+                fprintf(stderr, "qjs: missing filename for -p\n");
+                exit(1);
+                continue;
+            }
+            if (!strcmp(longopt, "profile-sampling")) {
+                if (optind >= argc) {
+                    fprintf(stderr, "expecting profile sampling");
+                    exit(1);
+                }
+                profile_sampling = (uint32_t)strtod(argv[optind++], NULL);
+                continue;
+            }
+#endif
             if (!strcmp(longopt, "std")) {
                 load_std = 1;
                 continue;
@@ -461,6 +525,12 @@ int main(int argc, char **argv)
         fprintf(stderr, "qjs: cannot allocate JS runtime\n");
         exit(2);
     }
+#ifdef CONFIG_PROFILE_CALLS
+    if(profile_file) {
+        JS_EnableProfileCalls(rt, profile_function_start, profile_function_end, profile_sampling, profile_file);
+        fprintf(profile_file, "{\"traceEvents\": [");
+    }
+#endif
     if (memory_limit != 0)
         JS_SetMemoryLimit(rt, memory_limit);
     if (stack_size != 0)
@@ -530,6 +600,13 @@ int main(int argc, char **argv)
     js_std_free_handlers(rt);
     JS_FreeContext(ctx);
     JS_FreeRuntime(rt);
+#ifdef CONFIG_PROFILE_CALLS
+    if(profile_file) {
+        // Inject an instant event at the end just to make sure it's valid JSON.
+        fprintf(profile_file, R"({"name": "end", "ph": "I", "ts": %ld, "pid": 1, "tid": 1, "s": "g"}]})", clock());
+        fclose(profile_file);
+    }
+#endif
 
     if (empty_run && dump_memory) {
         clock_t t[5];

--- a/quickjs.h
+++ b/quickjs.h
@@ -350,6 +350,31 @@ void JS_MarkValue(JSRuntime *rt, JSValueConst val, JS_MarkFunc *mark_func);
 void JS_RunGC(JSRuntime *rt);
 JS_BOOL JS_IsLiveObject(JSRuntime *rt, JSValueConst obj);
 
+/**
+ * Callback function type for handling JavaScript profiling events.
+ *
+ * @param func        Function name as a JSAtom. May be in the format "Constructor.name"
+ *                    when the function is executed in a constructor's context (i.e.,
+ *                    with 'this' binding)
+ * @param filename    Name of the source file containing the function, as a JSAtom
+ * @param opaque_data User data that was originally passed to JS_EnableProfileCalls.
+ *                    Same value is provided to both start and end handlers
+ */
+typedef void ProfileEventHandler(JSContext *ctx, JSAtom func, JSAtom filename, void *opaque_data);
+/**
+ * Enables function call profiling for the JavaScript runtime.
+ *
+ * NOTE: This function only works if QuickJS was compiled with -DCONFIG_PROFILE_CALLS flag.
+ *
+ * @param on_start    Callback called when a function starts.
+ * @param on_end      Callback called when a function ends.
+ * @param sampling    Controls profiling frequency: only 1/sampling function calls are
+ *                    instrumented. Must be ≥ 1. Example: if sampling=4, only 25% of
+ *                    function calls will trigger the handlers.
+ * @param opaque_data Optional user data passed to both handlers. Can be NULL.
+ */
+void JS_EnableProfileCalls(JSRuntime *rt, ProfileEventHandler *on_start, ProfileEventHandler *on_end, uint32_t sampling, void *opaque_data);
+
 JSContext *JS_NewContext(JSRuntime *rt);
 void JS_FreeContext(JSContext *s);
 JSContext *JS_DupContext(JSContext *ctx);


### PR DESCRIPTION
This pull request addresses #183 and builds upon the ideas introduced in #184, taking a slightly different approach to enhance flexibility and functionality:
- Profiling configuration is achieved by providing callback functions and optional opaque data. QuickJS will invoke these callbacks with relevant atoms for the function name and filename, along with the provided opaque data (e.g., a file handle for writing output). If possible, the function name includes the constructor of the "this" object, adding context. Unlike #184, which logs stats directly to stderr, this implementation offers greater flexibility by enabling client applications to massage the data in different ways (computing aggregated statistics, logging the raw events, etc).
- In #184, logging occurred in the bytecode destructor, which often led to function name atoms being collected prematurely, resulting in many functions being logged as `<:isGone:>`. This implementation resolves that by reporting profiling data at function entry and exit, ensuring the function name remains valid. Additionally, this approach includes context for functions (e.g., the constructor of the `this` object, akin to V8 stack traces for disambiguation) and flags anonymous functions explicitly.
- The qjs binary demonstrates an example usage of the profiling API by producing output in a format compatible with Chrome DevTools, chrome://tracing and tools like [Perfetto](https://ui.perfetto.dev/). By default, every call is logged, though the API (and qjs) supports configurable sampling. Here is an example of running `./qjs -p profile.json examples/pi_bigint.js 20` and then opening profile.json in the Chrome Dev Tools:
![image](https://github.com/user-attachments/assets/9fbb75fb-5646-4f40-b720-7dd03fad9949)

Please note that I'm not super familiar with QuickJS yet. I downloaded the code this week and have been playing with it only for a couple of days. Let me know if there are better ways to do some of the things I'm doing here, or if there is a coding style guide this change should adhere to.

Thanks!