### PR TITLE
fix crash when add property maybe failed on build arguments

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -14855,6 +14855,10 @@ static JSValue js_build_arguments(JSContext *ctx, int argc, JSValueConst *argv)
     /* add the length field (cannot fail) */
     pr = add_property(ctx, p, JS_ATOM_length,
                       JS_PROP_WRITABLE | JS_PROP_CONFIGURABLE);
+    if (!pr) {
+      JS_FreeValue(ctx, val);
+      return JS_EXCEPTION;
+    }
     pr->u.value = JS_NewInt32(ctx, argc);
 
     /* initialize the fast array part */
@@ -14904,6 +14908,8 @@ static JSValue js_build_mapped_arguments(JSContext *ctx, int argc,
     /* add the length field (cannot fail) */
     pr = add_property(ctx, p, JS_ATOM_length,
                       JS_PROP_WRITABLE | JS_PROP_CONFIGURABLE);
+    if (!pr)
+      goto fail;
     pr->u.value = JS_NewInt32(ctx, argc);
 
     for(i = 0; i < arg_count; i++) {


### PR DESCRIPTION
Hi,
We encountered a large number of online crashes, all of which were caused by insufficient memory when calling build arguments, resulting in the add_property call failing and returning null.
So I think there should be a judgment here instead of just letting it crash.

Thread
Scudo ERROR: internal map failure (NO MEMORY) requesting 4KB
*** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
pid: 0, tid: 6963 >>> com.xxx.dev <<<

backtrace:
  #00  pc 0x00000000000c4bfc  /data/app/~~xxx/lib/arm64/libquickjs.so
  #01  pc 0x0000000000064cd0  /data/app/~~xxx/lib/arm64/libquickjs.so
  #02  pc 0x0000000000065694  /data/app/~~xxx/lib/arm64/libquickjs.so
...


xxx arm64-v8a % aarch64-linux-android-addr2line -C -f -e libquickjs.so 0x00000000000c4bfc
js_build_arguments
xxx/quickjs.c:14858