### PR TITLE
regexp: Allow [\-] even in unicode mode

### DIFF
--- a/libregexp.c
+++ b/libregexp.c
@@ -700,8 +700,10 @@ static int get_class_atom(REParseState *s, CharRange *cr,
             if (ret >= 0) {
                 c = ret;
             } else {
-                if (ret == -2 && *p != '\0' && strchr("^$\\.*+?()[]{}|/", *p)) {
-                    /* always valid to escape these characters */
+                if (ret == -2 && *p != '\0'
+                    && strchr(inclass ? "-^$\\.*+?()[]{}|/" : "^$\\.*+?()[]{}|/", *p)) {
+                    /* always valid to escape these characters
+                       ("-" only in character classes) */
                     goto normal_char;
                 } else if (s->is_unicode) {
                 invalid_escape:


### PR DESCRIPTION
Hi! This is a straightforward fix for https://github.com/bellard/quickjs/issues/314.

I couldn't find information on what the correct behavior is, but this corresponds to the other JS engines I tried (Chrome + FF + Node).

Code style comments also welcome. There's probably a more preferable way to do this.