### PR TITLE
missing atomic references...

### DIFF
--- a/qjsc.c
+++ b/qjsc.c
@@ -451,6 +451,7 @@ static int output_executable(const char *out_filename, const char *cfilename,
     *arg++ = "-lm";
     *arg++ = "-ldl";
     *arg++ = "-lpthread";
+    *arg++ = "-latomic";
     *arg = NULL;
 
     if (verbose) {


### PR DESCRIPTION
EXTRA_LIBS='-latomic' is not enough...
	qjsc needs to pass the same for producing output.

same issue or possibly related to issue #321

compiling platform uname -a
	Linux raspberrypi 6.6.62+rpt-rpi-v8 #1 SMP PREEMPT Debian 1:6.6.62-1+rpt1 (2024-11-25) aarch64 GNU/Linux

	modified:   qjsc.c