### PR TITLE
Fix parsing dates with more than 9 contiguous digits

### DIFF
--- a/tests/test_builtin.js
+++ b/tests/test_builtin.js
@@ -540,12 +540,28 @@ function test_date()
     //   is not a valid instance of this format.
     // Hence the fractional part after . should have 3 digits and how
     // a different number of digits is handled is implementation defined.
+    // As of March, 2025 these tests match the results of v8 11.3
     assert(Date.parse(""), NaN);
+    assert(Date.parse("13"), NaN);
+    assert(Date.parse("31"), NaN);
+    assert(Date.parse("1000"), -30610224000000);
+    assert(Date.parse("1969"), -31536000000);
+    assert(Date.parse("1970"), 0);
     assert(Date.parse("2000"), 946684800000);
+    assert(Date.parse("9999"), 253370764800000);
+    assert(Date.parse("275761"), NaN);
+    assert(Date.parse("999999"), NaN);
+    assert(Date.parse("1000000000"), NaN);
+    assert(Date.parse("-271821"), NaN);
+    assert(Date.parse("-271820"), -8639977881600000);
+    assert(Date.parse("-100000"), -3217862419200000);
+    assert(Date.parse("+100000"), 3093527980800000);
+    assert(Date.parse("+275760"), 8639977881600000);
+    assert(Date.parse("+275761"), NaN);
     assert(Date.parse("2000-01"), 946684800000);
     assert(Date.parse("2000-01-01"), 946684800000);
-    //assert(Date.parse("2000-01-01T"), NaN);
-    //assert(Date.parse("2000-01-01T00Z"), NaN);
+    assert(Date.parse("2000-01-01T"), NaN);
+    assert(Date.parse("2000-01-01T00Z"), NaN);
     assert(Date.parse("2000-01-01T00:00Z"), 946684800000);
     assert(Date.parse("2000-01-01T00:00:00Z"), 946684800000);
     assert(Date.parse("2000-01-01T00:00:00.1Z"), 946684800100);


### PR DESCRIPTION
Most engines like v8, and current versions of spidermonkey versions (128 at least) return NaN while QuickJS parses up to 9 digits at a time, then tries to parse the rest. Trying to parse extra digits can sometimes produce random garbage. To fix it, when parsing the initial integer parse as many digits as we can (max = 0) instead of just 9.

Add a few tests, including uncommenting some previous ones, and ensure they pass on v8 version 11.

Fixes: #384