### PR TITLE
More CI tragets: Linux 32bit, Windows and Cosmopolitan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,44 @@ jobs:
         run: |
           make microbench
 
+  linux-lto:
+    name: Linux LTO
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Build
+        run: |
+          make -j$(getconf _NPROCESSORS_ONLN) CONFIG_WERROR=y CONFIG_LTO=y
+      - name: Run built-in tests
+        run: |
+          make test
+      - name: Run microbench
+        run: |
+          make microbench
+
+  linux-32bit:
+    name: Linux 32bit
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Install gcc-multilib
+        run: |
+          sudo apt install -y gcc-multilib
+      - name: Build
+        run: |
+          make -j$(getconf _NPROCESSORS_ONLN) CONFIG_WERROR=y CONFIG_M32=y
+      - name: Run built-in tests
+        run: |
+          make CONFIG_M32=y test
+
   linux-asan:
     runs-on: ubuntu-latest
     steps:
@@ -142,6 +180,85 @@ jobs:
             ./qjs -qd
             gmake test
 
+  cosmopolitan:
+    name: Cosmopolitan
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Install Cosmopolitan
+        run: |
+          mkdir ~/cosmocc
+          cd ~/cosmocc
+          wget https://cosmo.zip/pub/cosmocc/cosmocc.zip
+          unzip cosmocc.zip
+          echo "$HOME/cosmocc/bin" >> "$GITHUB_PATH"
+      - name: Build
+        run: |
+          make CONFIG_COSMO=y
+      - name: Run built-in tests
+        run: |
+          make CONFIG_COSMO=y test
+
+  mingw-windows:
+    name: MinGW Windows target
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Install MinGW and Wine
+        run: |
+          sudo apt install -y wine mingw-w64
+          cp /usr/x86_64-w64-mingw32/lib/libwinpthread-1.dll .
+      - name: Setup Wine
+        run: |
+          wine --version
+          winecfg /v
+          # binfmt doesn't work in GitHub Actions
+          #sudo apt install -y binfmt-support wine-binfmt
+          #echo ":Wine:M::MZ::/usr/bin/wine:" > /etc/binfmt.d/wine.conf
+          #sudo systemctl restart systemd-binfmt
+      - name: Build
+        run: |
+          make CONFIG_WIN32=y
+      - name: Run built-in tests
+        run: |
+          # If binfmt support worked, could just run `make CONFIG_WIN32=y test`
+          make WINE=/usr/bin/wine CONFIG_WIN32=y test
+
+  windows-msys:
+    name: Windows MSYS2
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
+          install: git make mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-dlfcn
+      - name: Build
+        run: |
+           make -j$(getconf _NPROCESSORS_ONLN) CONFIG_WERROR=y
+      - name: Stats
+        run: |
+          ./qjs -qd
+      - name: Run built-in tests
+        run: |
+          make test
+      - name: Run microbench
+        run: |
+          make microbench
+
+
   qemu-alpine:
     runs-on: ubuntu-latest
 
@@ -155,12 +272,14 @@ jobs:
           - linux/arm/v6
           - linux/arm/v7
           - linux/s390x
+          - linux/ppc64le
 
     steps:
       - uses: actions/checkout@v4
         with:
             submodules: recursive
       - name: Get qemu
-        run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+        # See https://github.com/tonistiigi/binfmt/issues/215#issuecomment-2613004741
+        run: docker run --privileged --rm tonistiigi/binfmt:master --install all
       - name: Run tests on ${{ matrix.platform }}
         run: docker run --rm --interactive --mount type=bind,source=$(pwd),target=/host --platform ${{ matrix.platform }} alpine sh -c "apk add git patch make gcc libc-dev && cd /host && make test"

--- a/.gitignore
+++ b/.gitignore
@@ -6,14 +6,20 @@ test_fib.c
 examples/*.so
 examples/hello
 examples/hello_module
+examples/hello.exe
+examples/test_fib.exe
 hello.c
 microbench*.txt
 qjs
+qjs.exe
 qjsc
+qjsc.exe
+host-qjsc
 qjscalc
 qjscalc.c
 repl.c
 run-test262
+run-test262.exe
 test262
 test262_*.txt
 test262o
@@ -22,3 +28,4 @@ unicode
 unicode_gen
 run_octane
 run_sunspider_like
+libwinpthread*.dll


### PR DESCRIPTION
Atomics support in Windows requires `libwinpthread*.dll` at runtime. One way to get it is to install it with MinGW package, and copy alongside the executable.

Update test Makefile targets for windows executables.

Allow running tests with Wine: `make WINE=wine CONFIG_WIN3=y...`. That's useful when Wine binfmt support cannot be installed such as on the CI hosts.

Add PPC64LE architecture and try to fix flaky multi-arch CI in gcc: https://github.com/tonistiigi/binfmt/issues/215

Fix issue: https://github.com/bellard/quickjs/issues/390