### PR TITLE
shared lib and  config file

### DIFF
--- a/quickjs.pc.in
+++ b/quickjs.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+libdir=@libdir@
+includedir=${prefix}/include
+
+Name: quickjs
+Description: JavaScript interpreting 
+URL: https://github.com/bellard/quickjs
+Version: @version@
+Libs: -L${libdir} -lquickjs
+Cflags: -I${includedir}


### PR DESCRIPTION
this will give packet manager the files they need

export PREFIX=/usr
export LIBDIR=lib/$HOST
export CFLAGS=-DNDEBUG

 static libs can't be used in the context of a packet system that has to consider storage and download size and battery driven computers several thousand metres from the antenna  . I am writing this from a hill overlooking south east Tasmania.  It is impossible  to store or download anything twice  . if you add this to your bashrc you can store the library in separate files in the same folder

export LD_LIBRARY_PATH=.

mashing everything into the same ELF is a disaster it has no internal structure it is impossible to undo the mess. there are other bundle formats that allow  extract the contents into separate files. you have to use flat pack or something else to bundle program files into a single runnable  file

 # android bionic bug

this uncovered a bug in /system/bin/linker64 or bionic dlopen that I was not aware of .  the only solution I found was to not use bionic I have no clue what they are up to half of the time only problem is all system drivers are bionic and can't be loaded from non bionic aapps. I currently only need the library for elinks

export LD_DEBUG=libs <- not implemented in bionic
qjs-shared examples/test_fib.js
perror=No such file or directory
ReferenceError: could not load module filename 'examples/fib.so' as shared library

export LD_LIBRARY_PATH=$(pwd):$(pwd)/examples/fib.so
WARNING: linker: Warning: "/data/data/com.termux/files/home/quickjs/examples/fib.so" is not a directory (ignoring)

$PREFIX/glibc/bash
export PATH=$PREFIX/glibc/bin:$PATH
export CFLAGS=-D__ANDROID__
...
Hello World
fib(10)= 55

 # to-do qjsc -shared

this creates a large file from libquickjs.a

qjsc examples/hello.js
ls -sh a.out
4.1M a.out

I would like to build a small file directly from  JS compiler.  a program that prints hello should not be four million bytes in a single file. it is impossible to inspect a compiled blob of code ELF format has no concept of internal objects everything is mashed into the text object. it is better to store the library in the same folder as the program
