### PR TITLE
Fix segfault on large number of properties

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -7860,6 +7860,17 @@ static int __exception JS_GetOwnPropertyNamesInternal(JSContext *ctx,
 
     /* fill them */
 
+    /* check for possible max_int overflow */
+    if(unlikely(
+         num_keys_count > 100000000
+      || str_keys_count > 100000000
+      || sym_keys_count > 100000000
+      || exotic_keys_count > 100000000
+    )) {
+        js_free_prop_enum(ctx, tab_exotic, exotic_count);
+        JS_ThrowOutOfMemory(ctx);
+        return -1;
+    }
     atom_count = num_keys_count + str_keys_count + sym_keys_count + exotic_keys_count;
     /* avoid allocating 0 bytes */
     tab_atom = js_malloc(ctx, sizeof(tab_atom[0]) * max_int(atom_count, 1));

--- a/tests/test_language.js
+++ b/tests/test_language.js
@@ -413,6 +413,15 @@ function test_spread()
 
     x = [ ...[ , ] ];
     assert(Object.getOwnPropertyNames(x).toString(), "0,length");
+
+    /* large property count doesn't segfault */
+    f = function many_props() {
+        const arr = new Int8Array(2147483646);
+        arr["foo"] = 1;
+        arr[Symbol("bar")] = 2;
+        obj = {...arr};
+    }
+    assert_throws(InternalError, f);
 }
 
 function test_function_length()


### PR DESCRIPTION
Previously, if the sum of the numeric, string, symbolic and exotic props overflowed MAX_INT32, we could be allocating a too small of a region and end up with a segfault.

Like in the fixed date parsing in case 030333cff616043858b32dc32405f9776372a0e6, check individual values against a reasonable max (100000000), and throw an out-of-memory exception before summing and letting them overflow.

Fix: https://github.com/bellard/quickjs/issues/111