### PR TITLE
fixed realloc(0) may alloc min unit memory on some allocator

### DIFF
--- a/libregexp.c
+++ b/libregexp.c
@@ -2448,7 +2448,7 @@ int lre_exec(uint8_t **capture,
     stack_buf = alloca(alloca_size);
     ret = lre_exec_backtrack(s, capture, stack_buf, 0, bc_buf + RE_HEADER_LEN,
                              cbuf + (cindex << cbuf_type), FALSE);
-    lre_realloc(s->opaque, s->state_stack, 0);
+    lre_free(s->opaque, s->state_stack);
     return ret;
 }
 

--- a/libregexp.h
+++ b/libregexp.h
@@ -56,5 +56,6 @@ int lre_check_stack_overflow(void *opaque, size_t alloca_size);
 /* must be provided by the user, return non zero if time out */
 int lre_check_timeout(void *opaque);
 void *lre_realloc(void *opaque, void *ptr, size_t size);
+void lre_free(void *opaque, void *ptr);
 
 #endif /* LIBREGEXP_H */

--- a/quickjs.c
+++ b/quickjs.c
@@ -44594,6 +44594,13 @@ void *lre_realloc(void *opaque, void *ptr, size_t size)
     return js_realloc_rt(ctx->rt, ptr, size);
 }
 
+void lre_free(void *opaque, void *ptr)
+{
+    JSContext *ctx = opaque;
+    /* No JS exception is raised here */
+    js_free_rt(ctx->rt, ptr);
+}
+
 static JSValue js_regexp_escape(JSContext *ctx, JSValueConst this_val,
                                 int argc, JSValueConst *argv)
 {


### PR DESCRIPTION
On some memory allocators, such as [hardened_malloc](https://github.com/GrapheneOS/hardened_malloc), realloc(0) will allocate a minimum unit of memory (16 bytes)

The hardened_malloc is used on [grapheneos](https://grapheneos.org/), a common operating system on android.

[h_malloc.c](https://github.com/GrapheneOS/hardened_malloc/blob/main/h_malloc.c#L1515C2-L1515C13)
```
static inline void *allocate_small(unsigned arena, size_t requested_size) {
    struct size_info info = get_size_info(requested_size);
    size_t size = likely(info.size) ? info.size : 16;

    struct size_class *c = &ro.size_class_metadata[arena][info.class];
    size_t slots = get_slots(info.class);
    size_t slab_size = get_slab_size(slots, size);
    ...
```