### PR TITLE
Make js_class_id_alloc thread-local to avoid the 1 << 16 maximum size limits

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -1293,7 +1293,7 @@ static const JSClassExoticMethods js_arguments_exotic_methods;
 static const JSClassExoticMethods js_string_exotic_methods;
 static const JSClassExoticMethods js_proxy_exotic_methods;
 static const JSClassExoticMethods js_module_ns_exotic_methods;
-static JSClassID js_class_id_alloc = JS_CLASS_INIT_COUNT;
+static _Thread_local JSClassID js_class_id_alloc = JS_CLASS_INIT_COUNT;
 
 static void js_trigger_gc(JSRuntime *rt, size_t size)
 {


### PR DESCRIPTION
We are using QuickJS's JSRuntime in separate threads. We encountered an issue where JS_NewClass could fail if JS_NewRuntime and JS_FreeRuntime are called hundreds of times across many forked threads.

In this patch, we make js_class_id_alloc thread-local to ensure that each forked thread's class ID starts at JS_CLASS_INIT_COUNT.