### PR TITLE
Adjust `lastIndex` to leading surrogate when inside a surrogate pair in unicode RegExp

### DIFF
--- a/tests/test_builtin.js
+++ b/tests/test_builtin.js
@@ -779,6 +779,21 @@ function test_regexp()
     /* Note: SpiderMonkey and v8 may not be correct */
     assert("abcAbC".replace(/[\q{BC|A}]/gvi,"X"), "XXXX");
     assert("abcAbC".replace(/[\q{BC|A}--a]/gvi,"X"), "aXAX");
+
+    a = /(?:)/gu;
+    a.lastIndex = 1;
+    a.exec("🐱");
+    assert(a.lastIndex, 0);
+
+    a.lastIndex = 1;
+    a.exec("a\udc00");
+    assert(a.lastIndex, 1);
+
+    a = /\u{10000}/vgd;
+    a.lastIndex = 1;
+    a = a.exec("\u{10000}_\u{10000}");
+    assert(a.indices[0][0], 0);
+    assert(a.indices[0][1], 2);
 }
 
 function test_symbol()


### PR DESCRIPTION
22.2.7.2 RegExpBuiltinExec:

> 11. If fullUnicode is true, let input be StringToCodePoints(S). Otherwise, let input be a List whose elements are the code units that are the elements of S.

> 13.b. Let inputIndex be the index into input of the character that was obtained from element lastIndex of S.


See also:
- https://github.com/tc39/ecma262/issues/128
- https://chromium-review.googlesource.com/c/v8/v8/+/6368822