### PR TITLE
fixed building with gcc and clang >= 19 and -Wextra -Werror flags

### DIFF
--- a/quickjs.h
+++ b/quickjs.h
@@ -1049,7 +1049,7 @@ static inline JSValue JS_NewCFunctionMagic(JSContext *ctx, JSCFunctionMagic *fun
                                            const char *name,
                                            int length, JSCFunctionEnum cproto, int magic)
 {
-    return JS_NewCFunction2(ctx, (JSCFunction *)func, name, length, cproto, magic);
+    return JS_NewCFunction2(ctx, (JSCFunction *)(void *)func, name, length, cproto, magic);
 }
 void JS_SetConstructor(JSContext *ctx, JSValueConst func_obj,
                        JSValueConst proto);


### PR DESCRIPTION
$ cat t.c
#include <quickjs.h>

int main() {
    JSRuntime *rt;
    rt = JS_NewRuntime();
    JS_FreeRuntime(rt);
    return 0;
}

$ clang-19 -I. -L. -Wextra -Wno-unused-parameter -Werror -o t t.c -lquickjs -lm In file included from t.c:1:
./quickjs.h:1052:34: error: cast from 'JSCFunctionMagic *' (aka 'struct JSValue (*)(struct JSContext *, struct JSValue, int, struct JSValue *, int)') to 'JSCFunction *' (aka 'struct JSValue (*)(struct JSContext *, struct JSValue, int, struct JSValue *)') converts to incompatible function type [-Werror,-Wcast-function-type-mismatch]
 1052 |     return JS_NewCFunction2(ctx, (JSCFunction *)func, name, length, cproto, magic);
      |                                  ^~~~~~~~~~~~~~~~~~~
1 error generated.
$ gcc-13 -I. -L. -Wextra -Wno-unused-parameter -Werror -o t t.c -lquickjs -lm
In file included from t.c:1:
./quickjs.h: In function ‘JS_NewCFunctionMagic’:
./quickjs.h:1052:34: error: cast between incompatible function types from ‘JSValue (*)(JSContext *, JSValue,  int,  JSValue *, int)’ to ‘JSValue (*)(JSContext *, JSValue,  int,  JSValue *)’ [-Werror=cast-function-type]
 1052 |     return JS_NewCFunction2(ctx, (JSCFunction *)func, name, length, cproto, magic);
      |                                  ^
cc1: all warnings being treated as errors