### PR TITLE
Fix crash on failure to read bytecode (arguments, local variables, etc.)

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -34952,7 +34952,8 @@ static void free_function_bytecode(JSRuntime *rt, JSFunctionBytecode *b)
                JS_AtomGetStrRT(rt, buf, sizeof(buf), b->func_name));
     }
 #endif
-    free_bytecode_atoms(rt, b->byte_code_buf, b->byte_code_len, TRUE);
+    if (b->byte_code_buf)
+        free_bytecode_atoms(rt, b->byte_code_buf, b->byte_code_len, TRUE);
 
     if (b->vardefs) {
         for(i = 0; i < b->arg_count + b->var_count; i++) {


### PR DESCRIPTION
We have encountered crashes in production related to bytecode reading. When reading specific parts of the bytecode (such as arguments, local variables, and other related data) fails, the subsequent release of the corresponding object may trigger a null pointer crash.

```
static JSValue JS_ReadFunctionTag(BCReaderState *s)
{    
    bc_read_trace(s, "args=%d vars=%d defargs=%d closures=%d cpool=%d\n",
                  b->arg_count, b->var_count, b->defined_arg_count,
                  b->closure_var_count, b->cpool_count);
    bc_read_trace(s, "stack=%d bclen=%d locals=%d\n",
                  b->stack_size, b->byte_code_len, local_count);

    if (local_count != 0) {
        bc_read_trace(s, "vars {\n");
        bc_read_trace(s, "off flags scope name\n");
        for(i = 0; i < local_count; i++) {
            JSVarDef *vd = &b->vardefs[i];
            if (bc_get_atom(s, &vd->var_name))
                // If this jump to fail, the bytecode object obj.byte_code_len will already have a value, but obj.byte_code_buf will still be null. Jumping to JS_FreeValue will crash at free_function_bytecode.
                goto fail; 
            if (bc_get_leb128_int(s, &vd->scope_level))
                goto fail;
            if (bc_get_leb128_int(s, &vd->scope_next))
                goto fail;
            vd->scope_next--;
            if (bc_get_u8(s, &v8))
```

**crash snapshot**
<img width="421" height="809" alt="image" src="https://github.com/user-attachments/assets/dc8fb343-c19e-4f3b-901f-e5da8b074186" />

