### PR TITLE
Modify the exit codes when providing specific options

### DIFF
--- a/qjs.c
+++ b/qjs.c
@@ -308,7 +308,6 @@ void help(void)
            "-s                    strip all the debug info\n"
            "    --strip-source    strip the source code\n"
            "-q  --quit         just instantiate the interpreter and quit\n");
-    exit(1);
 }
 
 int main(int argc, char **argv)
@@ -355,7 +354,7 @@ int main(int argc, char **argv)
                 arg++;
             if (opt == 'h' || opt == '?' || !strcmp(longopt, "help")) {
                 help();
-                continue;
+                exit(0);
             }
             if (opt == 'e' || !strcmp(longopt, "eval")) {
                 if (*arg) {
@@ -447,6 +446,7 @@ int main(int argc, char **argv)
                 fprintf(stderr, "qjs: unknown option '--%s'\n", longopt);
             }
             help();
+            exit(2);
         }
     }
 

--- a/qjsc.c
+++ b/qjsc.c
@@ -396,6 +396,7 @@ void help(void)
            "usage: " PROG_NAME " [options] [files]\n"
            "\n"
            "options are:\n"
+           "-h          list options\n"
            "-c          only output bytecode to a C file\n"
            "-e          output main() and bytecode to a C file (default = executable output)\n"
            "-o output   set the output filename\n"
@@ -423,7 +424,6 @@ void help(void)
                "            disable selected language features (smaller code size)\n");
     }
 #endif
-    exit(1);
 }
 
 #if defined(CONFIG_CC) && !defined(_WIN32)
@@ -625,7 +625,7 @@ int main(int argc, char **argv)
                 arg++;
             if (opt == 'h' || opt == '?' || !strcmp(longopt, "help")) {
                 help();
-                continue;
+                exit(0);
             }
             if (opt == 'o') {
                 out_filename = get_short_optarg(&optind, opt, arg, argc, argv);
@@ -723,11 +723,14 @@ int main(int argc, char **argv)
                 fprintf(stderr, "qjsc: unknown option '--%s'\n", longopt);
             }
             help();
+            exit(2);
         }
     }
 
-    if (optind >= argc)
+    if (optind >= argc) {
         help();
+        exit(2);
+    }
 
     if (!out_filename) {
         if (output_type == OUTPUT_EXECUTABLE) {

--- a/run-test262.c
+++ b/run-test262.c
@@ -2056,7 +2056,6 @@ void help(void)
            "-f file        execute single test from 'file'\n"
            "-r file        set the report file name (default=none)\n"
            "-x file        exclude tests listed in 'file'\n");
-    exit(1);
 }
 
 char *get_opt_arg(const char *option, char *arg)
@@ -2108,6 +2107,7 @@ int main(int argc, char **argv)
         optind++;
         if (str_equal(arg, "-h")) {
             help();
+            exit(0);
         } else if (str_equal(arg, "-m")) {
             dump_memory++;
         } else if (str_equal(arg, "-n")) {
@@ -2152,8 +2152,10 @@ int main(int argc, char **argv)
         }
     }
 
-    if (optind >= argc && !test_list.count)
+    if (optind >= argc && !test_list.count) {
         help();
+        exit(2);
+    }
 
     if (is_test262_harness) {
         return run_test262_harness_test(argv[optind], is_module);


### PR DESCRIPTION
- set the exit code to 0 for `-h` (etc.)

  This is useful when writing script, e.g., 
  
  ```bash
  if ! qjs -h >/dev/null; then
      echo 'Please install QuickJS'
      exit 1 
  fi
  ```

- make the `help()` function print only the help information

- call `exit(2)` when encountering invalid options or missing arguments

  It is appropriate to exit with code 2 when command-line arguments are used incorrectly.  (This is also the behavior of bash/make/grep.)
  <https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html>:

  > All builtins return an exit status of 2 to indicate incorrect usage, generally invalid options or missing arguments.