### PR TITLE
cherry-pick various memory buffer handling fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -454,6 +454,8 @@ test: qjs$(EXE)
 	$(WINE) ./qjs$(EXE) tests/test_bigint.js
 	$(WINE) ./qjs$(EXE) tests/test_cyclic_import.js
 	$(WINE) ./qjs$(EXE) tests/test_worker.js
+	$(WINE) ./qjs$(EXE) tests/bug1301.js
+	$(WINE) ./qjs$(EXE) tests/bug1302.js
 ifndef CONFIG_WIN32
 	$(WINE) ./qjs$(EXE) tests/test_std.js
 endif

--- a/Makefile
+++ b/Makefile
@@ -457,6 +457,7 @@ test: qjs$(EXE)
 	$(WINE) ./qjs$(EXE) tests/bug1301.js
 	$(WINE) ./qjs$(EXE) tests/bug1302.js
 	$(WINE) ./qjs$(EXE) tests/bug1305.js
+	$(WINE) ./qjs$(EXE) tests/bug1296.js
 ifndef CONFIG_WIN32
 	$(WINE) ./qjs$(EXE) tests/test_std.js
 endif

--- a/Makefile
+++ b/Makefile
@@ -456,6 +456,7 @@ test: qjs$(EXE)
 	$(WINE) ./qjs$(EXE) tests/test_worker.js
 	$(WINE) ./qjs$(EXE) tests/bug1301.js
 	$(WINE) ./qjs$(EXE) tests/bug1302.js
+	$(WINE) ./qjs$(EXE) tests/bug1305.js
 ifndef CONFIG_WIN32
 	$(WINE) ./qjs$(EXE) tests/test_std.js
 endif

--- a/quickjs.c
+++ b/quickjs.c
@@ -58121,6 +58121,10 @@ static JSValue js_typed_array_constructor_ta(JSContext *ctx,
         JS_ThrowTypeErrorArrayBufferOOB(ctx);
         goto fail;
     }
+    if (len > p->u.array.count) {
+        JS_ThrowRangeError(ctx, "length out of bounds");
+        goto fail;
+    }
     ta = p->u.typed_array;
     src_buffer = ta->buffer;
     src_abuf = src_buffer->u.array_buffer;

--- a/quickjs.c
+++ b/quickjs.c
@@ -58775,8 +58775,11 @@ static JSValue js_atomics_op(JSContext *ctx,
                     rep_val = v32;
                 }
         }
-        if (abuf->detached)
-            return JS_ThrowTypeErrorDetachedArrayBuffer(ctx);
+        /* the buffer may have been resized or detached during the
+           value conversion via valueOf(), so the pointer must be re-fetched */
+        if (js_atomics_get_ptr(ctx, &ptr, &abuf, &size_log2, &class_id,
+                               argv[0], argv[1], 0))
+            return JS_EXCEPTION;
    }
 
    switch(op | (size_log2 << 3)) {
@@ -58901,8 +58904,12 @@ static JSValue js_atomics_store(JSContext *ctx,
             JS_FreeValue(ctx, ret);
             return JS_EXCEPTION;
         }
-        if (abuf->detached)
-            return JS_ThrowTypeErrorDetachedArrayBuffer(ctx);
+        /* buffer may have been resized or detached during value conversion */
+        if (js_atomics_get_ptr(ctx, &ptr, &abuf, &size_log2, NULL,
+                               argv[0], argv[1], 0)) {
+            JS_FreeValue(ctx, ret);
+            return JS_EXCEPTION;
+        }
         atomic_store((_Atomic(uint64_t) *)ptr, v64);
     } else {
         uint32_t v;
@@ -58914,8 +58921,12 @@ static JSValue js_atomics_store(JSContext *ctx,
             JS_FreeValue(ctx, ret);
             return JS_EXCEPTION;
         }
-        if (abuf->detached)
-            return JS_ThrowTypeErrorDetachedArrayBuffer(ctx);
+        /* buffer may have been resized or detached during value conversion */
+        if (js_atomics_get_ptr(ctx, &ptr, &abuf, &size_log2, NULL,
+                               argv[0], argv[1], 0)) {
+            JS_FreeValue(ctx, ret);
+            return JS_EXCEPTION;
+        }
         switch(size_log2) {
         case 0:
             atomic_store((_Atomic(uint8_t) *)ptr, v);

--- a/quickjs.c
+++ b/quickjs.c
@@ -58228,6 +58228,27 @@ static JSValue js_typed_array_constructor(JSContext *ctx,
         JS_FreeValue(ctx, buffer);
         return JS_EXCEPTION;
     }
+    // Re-validate buffer after js_create_from_ctor which may have run JS code
+    // that resized or detached the ArrayBuffer
+    abuf = JS_VALUE_GET_OBJ(buffer)->u.array_buffer;
+    if (abuf->detached) {
+        JS_FreeValue(ctx, buffer);
+        JS_FreeValue(ctx, obj);
+        return JS_ThrowTypeErrorDetachedArrayBuffer(ctx);
+    }
+    if (offset > abuf->byte_length) {
+        JS_FreeValue(ctx, buffer);
+        JS_FreeValue(ctx, obj);
+        return JS_ThrowRangeError(ctx, "invalid offset");
+    }
+    if (track_rab) {
+        // Recalculate length for RAB-backed view
+        len = (abuf->byte_length - offset) >> size_log2;
+    } else if ((offset + (len << size_log2)) > abuf->byte_length) {
+        JS_FreeValue(ctx, buffer);
+        JS_FreeValue(ctx, obj);
+        return JS_ThrowRangeError(ctx, "invalid length");
+    }
     if (typed_array_init(ctx, obj, buffer, offset, len, track_rab)) {
         JS_FreeValue(ctx, obj);
         return JS_EXCEPTION;

--- a/tests/bug1296.js
+++ b/tests/bug1296.js
@@ -1,0 +1,13 @@
+import {assert} from "./assert.js"
+
+const ab = new ArrayBuffer(10, { maxByteLength: 10 });
+function f() {
+    return 1337;
+}
+const evil = f.bind();
+
+Object.defineProperty(evil, "prototype", { get: () => {
+    return ab.resize();
+} });
+let u8 = Reflect.construct(Uint8Array, [ab], evil);
+assert(u8.length == 0);

--- a/tests/bug1301.js
+++ b/tests/bug1301.js
@@ -1,0 +1,21 @@
+/*---
+features: [skip-if-tcc]
+---*/
+
+import {assert} from "./assert.js"
+
+const rab = new ArrayBuffer(1024, { maxByteLength: 1024 * 1024 });
+const i32 = new Int32Array(rab);
+const evil = {
+    valueOf: () => {
+        rab.resize(0);
+        return 123;
+    }
+};
+
+try {
+  Atomics.store(i32, 0, evil);
+  throw Error("Should not get here");
+} catch (e) {
+  assert(e instanceof RangeError);
+}

--- a/tests/bug1302.js
+++ b/tests/bug1302.js
@@ -1,0 +1,24 @@
+/*---
+features: [skip-if-tcc]
+---*/
+
+import {assert} from "./assert.js"
+
+const rab = new ArrayBuffer(1024, { maxByteLength: 1024 * 1024 });
+const i32 = new Int32Array(rab);
+const evil = {
+    valueOf: () => {
+        rab.resize(0);
+        return 123;
+    }
+};
+try {
+  Atomics.add(i32, 0, evil);
+  // Atomics.sub(i32, 0, evil);
+  // Atomics.and(i32, 0, evil);
+  // Atomics.or(i32, 0, evil);
+  // Atomics.xor(i32, 0, evil);
+  throw Error("Should not get here");
+} catch (e) {
+  assert(e instanceof RangeError);
+}

--- a/tests/bug1305.js
+++ b/tests/bug1305.js
@@ -1,0 +1,26 @@
+import {assert} from "./assert.js"
+
+const rab = new ArrayBuffer(10, { maxByteLength: 10 });
+const src = new Uint8Array(rab, 0);
+
+function f() {
+    return 1337;
+}
+
+const EvilConstructor = new Proxy(function(){}, {
+    get: function(target, prop, receiver) {
+        if (prop === 'prototype') {
+            rab.resize(0);
+            return Uint8Array.prototype;
+        }
+        return Reflect.get(target, prop, receiver);
+    }
+});
+
+try {
+  let u8 = Reflect.construct(Uint8Array, [src], EvilConstructor);
+  print(u8);
+  throw Error("Should not get here");
+} catch (e) {
+  assert(e instanceof RangeError);
+}


### PR DESCRIPTION
Fix from https://github.com/bellard/quickjs/pull/480 with tests from https://github.com/quickjs-ng/quickjs/issues/1301 and https://github.com/quickjs-ng/quickjs/issues/1302
Fixes from https://github.com/quickjs-ng/quickjs/issues/1305 and https://github.com/quickjs-ng/quickjs/issues/1296