### PR TITLE
Avoid initializer-string warning for the digits array

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -12143,7 +12143,11 @@ static JSBigInt *js_bigint_from_string(JSContext *ctx,
 }
 
 /* 2 <= base <= 36 */
-static char const digits[36] = "0123456789abcdefghijklmnopqrstuvwxyz";
+static char const digits[36] = {
+  '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b',
+  'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n',
+  'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'
+};
 
 /* special version going backwards */
 /* XXX: use dtoa.c */


### PR DESCRIPTION
Some newer compilers emit this warning:

```
warning: initializer-string for character array is too long, array size is 36 
     but initializer has size 37 (including the null terminating character);
     did you mean to use the 'nonstring' attribute? [-Wunterminated-string-initialization]
 12146 | static char const digits[36] = "0123456789abcdefghijklmnopqrstuvwxyz";
       |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

To avoid the warning initialize the array as individual characters