### PR TITLE
trim `CHUD_BITS_PER_TERM` precision in `examples/pi_bigint.js`

### DIFF
--- a/examples/pi_bigint.js
+++ b/examples/pi_bigint.js
@@ -53,7 +53,7 @@ function calc_pi(prec) {
     const CHUD_B = 545140134n;
     const CHUD_C = 640320n;
     const CHUD_C3 = 10939058860032000n; /* C^3/24 */
-    const CHUD_BITS_PER_TERM = 47.11041313821584202247; /* log2(C/12)*3 */
+    const CHUD_BITS_PER_TERM = 47.11041313821584; /* log2(C/12)*3 */
 
     /* return [P, Q, G] */
     function chud_bs(a, b, need_G) {

--- a/tests/test_bigint.js
+++ b/tests/test_bigint.js
@@ -193,7 +193,7 @@ function calc_pi(prec) {
     const CHUD_B = 545140134n;
     const CHUD_C = 640320n;
     const CHUD_C3 = 10939058860032000n; /* C^3/24 */
-    const CHUD_BITS_PER_TERM = 47.11041313821584202247; /* log2(C/12)*3 */
+    const CHUD_BITS_PER_TERM = 47.11041313821584; /* log2(C/12)*3 */
 
     /* return [P, Q, G] */
     function chud_bs(a, b, need_G) {


### PR DESCRIPTION
Fixes a ESLint [no-loss-of-precision](https://eslint.org/docs/latest/rules/no-loss-of-precision) error on the `CHUD_BITS_PER_TERM` constant. 

The current value `47.11041313821584202247` contains 20 decimal digits, which exceeds JavaScript's **IEEE 754** double-precision floating-point representation limit.

---

- ESLint [playground](https://eslint.org/play/#eyJ0ZXh0IjoiLyplc2xpbnQgbm8tbG9zcy1vZi1wcmVjaXNpb246IFwiZXJyb3JcIiovXG5cbmNvbnN0IENIVURfQklUU19QRVJfVEVSTV9hID0gNDcuMTEwNDEzMTM4MjE1ODQyMDIyNDc7XG5jb25zdCBDSFVEX0JJVFNfUEVSX1RFUk1fYiA9IDQ3LjExMDQxMzEzODIxNTg0OyIsIm9wdGlvbnMiOnsicnVsZXMiOnt9LCJsYW5ndWFnZU9wdGlvbnMiOnsicGFyc2VyT3B0aW9ucyI6eyJlY21hRmVhdHVyZXMiOnt9fX19fQ==)