### PR TITLE
avoid out-of-bounds opcode read in JS_ReadFunctionBytecode

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -37545,6 +37545,8 @@ static void bc_byte_swap(uint8_t *bc_buf, int bc_len)
     while (pos < bc_len) {
         op = bc_buf[pos];
         len = short_opcode_info(op).size;
+        if (pos + len > bc_len)
+            break;
         fmt = short_opcode_info(op).fmt;
         switch(fmt) {
         case OP_FMT_u16:
@@ -38523,6 +38525,12 @@ static int JS_ReadFunctionBytecode(BCReaderState *s, JSFunctionBytecode *b,
     while (pos < bc_len) {
         op = bc_buf[pos];
         len = short_opcode_info(op).size;
+        if (unlikely(pos + len > bc_len)) {
+            /* the opcode reads past the end of the bytecode: avoid
+               fetching or relocating an atom out of bounds */
+            b->byte_code_len = pos;
+            return bc_read_error_end(s);
+        }
         switch(short_opcode_info(op).fmt) {
         case OP_FMT_atom:
         case OP_FMT_atom_u8:


### PR DESCRIPTION
JS_ReadFunctionBytecode walks the serialized opcode stream and, for the atom formats, reads a 4-byte operand at get_u32(bc_buf + pos + 1) and rewrites it with put_u32. The loop only checks pos < bc_len, not that the whole opcode fits, so a function whose byte_code ends in a truncated atom opcode reads and relocates up to four bytes past the bytecode allocation. JS_ReadObject with JS_READ_OBJ_BYTECODE reaches this; ASan reports a heap-buffer-overflow READ of size 4 on a 17-byte blob whose 1-byte byte_code is a single OP_push_atom_value. bc_byte_swap has the same unchecked walk on big-endian targets.

Before, the reader trusted the opcode size to stay within byte_code_len and stepped pos past the end only after touching the operand. After, each iteration rejects an opcode that would extend past bc_len before any operand is read, and rewinds b->byte_code_len to the validated prefix so atom cleanup frees only what was already relocated, matching the existing truncated-atom error path. The check sits in the reader because the operand bytes come straight from the input buffer and no caller can make a short opcode whole. Tradeoff: a deliberately truncated final opcode now fails the load with a SyntaxError instead of being silently tolerated.
