### PR TITLE
Harden and optimize RegExp execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -251,7 +251,9 @@ all: $(OBJDIR) $(OBJDIR)/quickjs.check.o $(OBJDIR)/qjs.check.o $(PROGS)
 
 QJS_LIB_OBJS=$(OBJDIR)/quickjs.o $(OBJDIR)/dtoa.o $(OBJDIR)/libregexp.o $(OBJDIR)/libunicode.o $(OBJDIR)/cutils.o $(OBJDIR)/quickjs-libc.o
 
-QJS_OBJS=$(OBJDIR)/qjs.o $(OBJDIR)/repl.o $(QJS_LIB_OBJS)
+QJS_BC_OBJS=$(OBJDIR)/quickjs-bytecode.o
+
+QJS_OBJS=$(OBJDIR)/qjs.o $(OBJDIR)/repl.o $(QJS_BC_OBJS) $(QJS_LIB_OBJS)
 
 HOST_LIBS=-lm -ldl -lpthread
 LIBS=-lm -lpthread
@@ -269,7 +271,7 @@ qjs$(EXE): $(QJS_OBJS)
 qjs-debug$(EXE): $(patsubst %.o, %.debug.o, $(QJS_OBJS))
 	$(CC) $(LDFLAGS) -o $@ $^ $(LIBS)
 
-qjsc$(EXE): $(OBJDIR)/qjsc.o $(QJS_LIB_OBJS)
+qjsc$(EXE): $(OBJDIR)/qjsc.o $(QJS_BC_OBJS) $(QJS_LIB_OBJS)
 	$(CC) $(LDFLAGS) -o $@ $^ $(LIBS)
 
 fuzz_eval: $(OBJDIR)/fuzz_eval.o $(OBJDIR)/fuzz_common.o libquickjs.fuzz.a
@@ -286,7 +288,7 @@ libfuzzer: fuzz_eval fuzz_compile fuzz_regexp
 ifneq ($(CROSS_PREFIX),)
 
 $(QJSC): $(OBJDIR)/qjsc.host.o \
-    $(patsubst %.o, %.host.o, $(QJS_LIB_OBJS))
+    $(patsubst %.o, %.host.o, $(QJS_BC_OBJS) $(QJS_LIB_OBJS))
 	$(HOST_CC) $(LDFLAGS) -o $@ $^ $(HOST_LIBS)
 
 endif #CROSS_PREFIX
@@ -369,7 +371,7 @@ clean:
 	rm -f repl.c out.c
 	rm -f *.a *.o *.d *~ unicode_gen regexp_test fuzz_eval fuzz_compile fuzz_regexp $(PROGS)
 	rm -f hello.c test_fib.c
-	rm -f examples/*.so tests/*.so
+	rm -f examples/*.so tests/*.so tests/*.qbc examples/*.qbc
 	rm -rf $(OBJDIR)/ *.dSYM/ qjs-debug$(EXE)
 	rm -rf run-test262-debug$(EXE)
 	rm -f run_octane run_sunspider_like
@@ -452,21 +454,44 @@ ifdef CONFIG_SHARED_LIBS
 test: tests/bjson.so examples/point.so
 endif
 
-test: qjs$(EXE)
+test: qjs$(EXE) qjsc$(EXE)
 	$(WINE) ./qjs$(EXE) tests/test_closure.js
+	$(WINE) ./qjsc$(EXE) --bytecode -o tests/test_closure.qbc tests/test_closure.js
+	$(WINE) ./qjs$(EXE) --bytecode tests/test_closure.qbc
 	$(WINE) ./qjs$(EXE) tests/test_language.js
+	$(WINE) ./qjsc$(EXE) --bytecode -o tests/test_language.qbc tests/test_language.js
+	$(WINE) ./qjs$(EXE) --bytecode tests/test_language.qbc
 	$(WINE) ./qjs$(EXE) --std tests/test_builtin.js
+	$(WINE) ./qjsc$(EXE) --bytecode -o tests/test_builtin.qbc tests/test_builtin.js
+	$(WINE) ./qjs$(EXE) --std --bytecode tests/test_builtin.qbc
 	$(WINE) ./qjs$(EXE) tests/test_loop.js
+	$(WINE) ./qjsc$(EXE) --bytecode -o tests/test_loop.qbc tests/test_loop.js
+	$(WINE) ./qjs$(EXE) --bytecode tests/test_loop.qbc
 	$(WINE) ./qjs$(EXE) tests/test_bigint.js
+	$(WINE) ./qjsc$(EXE) --bytecode -o tests/test_bigint.qbc tests/test_bigint.js
+	$(WINE) ./qjs$(EXE) --bytecode tests/test_bigint.qbc
 	$(WINE) ./qjs$(EXE) tests/test_cyclic_import.js
+	$(WINE) ./qjsc$(EXE) --bytecode -o tests/test_cyclic_import.qbc tests/test_cyclic_import.js
+	$(WINE) ./qjs$(EXE) --bytecode tests/test_cyclic_import.qbc
 	$(WINE) ./qjs$(EXE) tests/test_worker.js
+	$(WINE) ./qjsc$(EXE) --bytecode -o tests/test_worker.qbc tests/test_worker.js
+	$(WINE) ./qjs$(EXE) --bytecode tests/test_worker.qbc
 ifndef CONFIG_WIN32
 	$(WINE) ./qjs$(EXE) tests/test_std.js
+	$(WINE) ./qjsc$(EXE) --bytecode -o tests/test_std.qbc tests/test_std.js
+	$(WINE) ./qjs$(EXE) --bytecode tests/test_std.qbc
 	$(WINE) ./qjs$(EXE) tests/test_rw_handler.js
+	$(WINE) ./qjsc$(EXE) --bytecode -o tests/test_rw_handler.qbc tests/test_rw_handler.js
+	$(WINE) ./qjs$(EXE) --bytecode tests/test_rw_handler.qbc
+	./tests/test_bytecode_file.sh
 endif
 ifdef CONFIG_SHARED_LIBS
 	$(WINE) ./qjs$(EXE) tests/test_bjson.js
+	$(WINE) ./qjsc$(EXE) --bytecode -o tests/test_bjson.qbc tests/test_bjson.js
+	$(WINE) ./qjs$(EXE) --bytecode tests/test_bjson.qbc
 	$(WINE) ./qjs$(EXE) examples/test_point.js
+	$(WINE) ./qjsc$(EXE) --bytecode -o examples/test_point.qbc examples/test_point.js
+	$(WINE) ./qjs$(EXE) --bytecode examples/test_point.qbc
 endif
 
 stats: qjs$(EXE)

--- a/Makefile
+++ b/Makefile
@@ -364,12 +364,20 @@ $(OBJDIR)/%.check.o: %.c | $(OBJDIR)
 regexp_test: libregexp.c libunicode.c cutils.c
 	$(CC) $(LDFLAGS) $(CFLAGS) -DTEST -o $@ libregexp.c libunicode.c cutils.c $(LIBS)
 
+tests/test_regexp_bytecode$(EXE): tests/test_regexp_bytecode.c libregexp.c libunicode.c cutils.c
+	$(CC) $(LDFLAGS) $(CFLAGS) -I. -o $@ tests/test_regexp_bytecode.c libregexp.c libunicode.c cutils.c $(LIBS)
+
+tests/qbc_regexp_mutator$(EXE): tests/qbc_regexp_mutator.c libregexp.c libunicode.c cutils.c
+	$(CC) $(LDFLAGS) $(CFLAGS) -I. -o $@ tests/qbc_regexp_mutator.c libregexp.c libunicode.c cutils.c $(LIBS)
+
 unicode_gen: $(OBJDIR)/unicode_gen.host.o $(OBJDIR)/cutils.host.o libunicode.c unicode_gen_def.h
 	$(HOST_CC) $(LDFLAGS) $(CFLAGS) -o $@ $(OBJDIR)/unicode_gen.host.o $(OBJDIR)/cutils.host.o
 
 clean:
 	rm -f repl.c out.c
 	rm -f *.a *.o *.d *~ unicode_gen regexp_test fuzz_eval fuzz_compile fuzz_regexp $(PROGS)
+	rm -f tests/test_regexp_bytecode$(EXE)
+	rm -f tests/qbc_regexp_mutator$(EXE)
 	rm -f hello.c test_fib.c
 	rm -f examples/*.so tests/*.so tests/*.qbc examples/*.qbc
 	rm -rf $(OBJDIR)/ *.dSYM/ qjs-debug$(EXE)
@@ -454,7 +462,8 @@ ifdef CONFIG_SHARED_LIBS
 test: tests/bjson.so examples/point.so
 endif
 
-test: qjs$(EXE) qjsc$(EXE)
+test: qjs$(EXE) qjsc$(EXE) tests/test_regexp_bytecode$(EXE) tests/qbc_regexp_mutator$(EXE)
+	$(WINE) ./tests/test_regexp_bytecode$(EXE)
 	$(WINE) ./qjs$(EXE) tests/test_closure.js
 	$(WINE) ./qjsc$(EXE) --bytecode -o tests/test_closure.qbc tests/test_closure.js
 	$(WINE) ./qjs$(EXE) --bytecode tests/test_closure.qbc

--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ DEFINES+=-DHAVE_CLOSEFROM
 endif
 endif
 
-CFLAGS+=$(DEFINES)
+CFLAGS+=$(DEFINES) $(EXTRA_CFLAGS)
 CFLAGS_DEBUG=$(CFLAGS) -O0
 CFLAGS_SMALL=$(CFLAGS) -Os
 CFLAGS_OPT=$(CFLAGS) -O2
@@ -370,6 +370,12 @@ tests/test_regexp_bytecode$(EXE): tests/test_regexp_bytecode.c libregexp.c libun
 tests/qbc_regexp_mutator$(EXE): tests/qbc_regexp_mutator.c libregexp.c libunicode.c cutils.c
 	$(CC) $(LDFLAGS) $(CFLAGS) -I. -o $@ tests/qbc_regexp_mutator.c libregexp.c libunicode.c cutils.c $(LIBS)
 
+tests/test_regexp_interrupt$(EXE): tests/test_regexp_interrupt.c $(QJS_LIB_OBJS)
+	$(CC) $(LDFLAGS) $(CFLAGS_OPT) -I. -o $@ tests/test_regexp_interrupt.c $(QJS_LIB_OBJS) $(LIBS)
+
+tests/test_regexp_threads$(EXE): tests/test_regexp_threads.c $(QJS_LIB_OBJS)
+	$(CC) $(LDFLAGS) $(CFLAGS_OPT) -I. -o $@ tests/test_regexp_threads.c $(QJS_LIB_OBJS) $(LIBS)
+
 unicode_gen: $(OBJDIR)/unicode_gen.host.o $(OBJDIR)/cutils.host.o libunicode.c unicode_gen_def.h
 	$(HOST_CC) $(LDFLAGS) $(CFLAGS) -o $@ $(OBJDIR)/unicode_gen.host.o $(OBJDIR)/cutils.host.o
 
@@ -378,6 +384,8 @@ clean:
 	rm -f *.a *.o *.d *~ unicode_gen regexp_test fuzz_eval fuzz_compile fuzz_regexp $(PROGS)
 	rm -f tests/test_regexp_bytecode$(EXE)
 	rm -f tests/qbc_regexp_mutator$(EXE)
+	rm -f tests/test_regexp_interrupt$(EXE)
+	rm -f tests/test_regexp_threads$(EXE)
 	rm -f hello.c test_fib.c
 	rm -f examples/*.so tests/*.so tests/*.qbc examples/*.qbc
 	rm -rf $(OBJDIR)/ *.dSYM/ qjs-debug$(EXE)
@@ -462,8 +470,10 @@ ifdef CONFIG_SHARED_LIBS
 test: tests/bjson.so examples/point.so
 endif
 
-test: qjs$(EXE) qjsc$(EXE) tests/test_regexp_bytecode$(EXE) tests/qbc_regexp_mutator$(EXE)
+test: qjs$(EXE) qjsc$(EXE) tests/test_regexp_bytecode$(EXE) tests/test_regexp_interrupt$(EXE) tests/test_regexp_threads$(EXE) tests/qbc_regexp_mutator$(EXE)
 	$(WINE) ./tests/test_regexp_bytecode$(EXE)
+	$(WINE) ./tests/test_regexp_interrupt$(EXE)
+	$(WINE) ./tests/test_regexp_threads$(EXE)
 	$(WINE) ./qjs$(EXE) tests/test_closure.js
 	$(WINE) ./qjsc$(EXE) --bytecode -o tests/test_closure.qbc tests/test_closure.js
 	$(WINE) ./qjs$(EXE) --bytecode tests/test_closure.qbc

--- a/libregexp.c
+++ b/libregexp.c
@@ -536,6 +536,128 @@ static int re_append_quick_check_metadata(REParseState *s, int re_flags)
     return dbuf_error(&s->byte_code) ? -1 : 1;
 }
 
+static BOOL re_single_char_opcode_end(const uint8_t *code, size_t code_len,
+                                      size_t pos, size_t *pend)
+{
+    size_t len;
+    int n, opcode;
+
+    if (pos >= code_len)
+        return FALSE;
+    opcode = code[pos];
+    switch(opcode) {
+    case REOP_char:
+    case REOP_char32:
+    case REOP_dot:
+    case REOP_any:
+    case REOP_space:
+    case REOP_not_space:
+        len = reopcode_info[opcode].size;
+        break;
+    case REOP_range:
+        if (pos + 3 > code_len)
+            return FALSE;
+        n = get_u16(code + pos + 1);
+        if (n == 0 || (size_t)n > (code_len - pos - 3) / 4)
+            return FALSE;
+        len = 3 + (size_t)n * 4;
+        break;
+    case REOP_range32:
+        if (pos + 3 > code_len)
+            return FALSE;
+        n = get_u16(code + pos + 1);
+        if (n == 0 || (size_t)n > (code_len - pos - 3) / 8)
+            return FALSE;
+        len = 3 + (size_t)n * 8;
+        break;
+    default:
+        return FALSE;
+    }
+    if (len > code_len - pos)
+        return FALSE;
+    *pend = pos + len;
+    return TRUE;
+}
+
+/* Detect (^|X)c where X consumes exactly one character. A match can only
+   start at the beginning of the input or immediately before c. */
+static BOOL re_get_leading_char_filter(const uint8_t *bc_buf,
+                                       size_t bc_buf_len, int re_flags,
+                                       uint32_t *chars, int *pchar_count)
+{
+    const uint8_t *code;
+    size_t pos, branch1, branch2, branch2_end, join;
+    int capture_index, char_count, opcode;
+    uint32_t c;
+
+    if (re_flags & (LRE_FLAG_IGNORECASE | LRE_FLAG_MULTILINE |
+                    LRE_FLAG_STICKY | LRE_FLAG_UNICODE |
+                    LRE_FLAG_UNICODE_SETS))
+        return FALSE;
+    if (bc_buf_len < RE_HEADER_LEN + 20)
+        return FALSE;
+    code = bc_buf + RE_HEADER_LEN;
+    bc_buf_len -= RE_HEADER_LEN;
+    if (code[0] != REOP_split_goto_first || get_i32(code + 1) != 6 ||
+        code[5] != REOP_any || code[6] != REOP_goto ||
+        get_i32(code + 7) != -11 || code[11] != REOP_save_start ||
+        code[12] != 0)
+        return FALSE;
+
+    pos = 13;
+    capture_index = -1;
+    if (pos + 2 <= bc_buf_len && code[pos] == REOP_save_start) {
+        capture_index = code[pos + 1];
+        pos += 2;
+    }
+    if (pos + 5 > bc_buf_len ||
+        (code[pos] != REOP_split_goto_first &&
+         code[pos] != REOP_split_next_first))
+        return FALSE;
+    branch1 = pos + 5;
+    branch2 = branch1 + get_i32(code + pos + 1);
+    if (branch2 <= branch1 || branch2 >= bc_buf_len ||
+        code[branch1] != REOP_line_start ||
+        branch1 + 6 > bc_buf_len || code[branch1 + 1] != REOP_goto)
+        return FALSE;
+    join = branch1 + 6 + get_i32(code + branch1 + 2);
+    if (join > bc_buf_len ||
+        !re_single_char_opcode_end(code, bc_buf_len, branch2, &branch2_end) ||
+        branch2_end != join)
+        return FALSE;
+    pos = join;
+    if (capture_index >= 0) {
+        if (pos + 2 > bc_buf_len || code[pos] != REOP_save_end ||
+            code[pos + 1] != capture_index)
+            return FALSE;
+        pos += 2;
+    }
+    char_count = 0;
+    while (pos < bc_buf_len && char_count < 4) {
+        opcode = code[pos];
+        if (opcode == REOP_char) {
+            if (pos + 3 > bc_buf_len)
+                return FALSE;
+            c = get_u16(code + pos + 1);
+            pos += 3;
+        } else if (opcode == REOP_char32) {
+            if (pos + 5 > bc_buf_len)
+                return FALSE;
+            c = get_u32(code + pos + 1);
+            if (c > 0xffff)
+                return FALSE;
+            pos += 5;
+        } else {
+            break;
+        }
+        chars[char_count++] = c;
+    }
+    if (char_count == 0)
+        return FALSE;
+    *pchar_count = char_count;
+    return TRUE;
+}
+
 static int lre_parse_metadata(const uint8_t *bc_buf, size_t bc_buf_len,
                               LREMetadata *meta, const uint8_t **ptrailer)
 {
@@ -3218,7 +3340,7 @@ typedef struct {
 
     StackElem *stack_buf;
     size_t stack_size;
-    StackElem static_stack_buf[32]; /* static stack to avoid allocation in most cases */
+    StackElem static_stack_buf[128]; /* static stack to avoid allocation in most cases */
 } REExecContext;
 
 static int lre_poll_timeout(REExecContext *s)
@@ -3336,8 +3458,13 @@ static intptr_t lre_exec_backtrack(REExecContext *s, uint8_t **capture,
         no_match:
             for(;;) {
                 REExecStateEnum type;
-                if (bp == s->stack_buf)
+                if (bp == s->stack_buf) {
+                    while (sp > bp) {
+                        capture[sp[-2].val] = sp[-1].ptr;
+                        sp -= 2;
+                    }
                     return 0;
+                }
                 /* undo the modifications to capture[] */
                 while (sp > bp) {
                     capture[sp[-2].val] = sp[-1].ptr;
@@ -3804,6 +3931,75 @@ static intptr_t lre_exec_backtrack(REExecContext *s, uint8_t **capture,
     }
 }
 
+static const uint8_t *lre_find_leading_char_candidate(REExecContext *s,
+                                                       const uint8_t *cptr,
+                                                       const uint32_t *chars,
+                                                       int char_count,
+                                                       int *pret)
+{
+    int i;
+
+    if (cptr >= s->cbuf_end)
+        return NULL;
+    if (cptr == s->cbuf) {
+        const uint8_t *p = cptr;
+
+        for(i = 0; i < char_count; i++) {
+            uint32_t c;
+
+            if (p >= s->cbuf_end)
+                break;
+            GET_CHAR(c, p, s->cbuf_end, s->cbuf_type);
+            if (c != chars[i])
+                break;
+        }
+        if (i == char_count)
+            return cptr;
+    }
+    if (s->cbuf_type == 0) {
+        const uint8_t *p, *search;
+
+        for(i = 0; i < char_count; i++) {
+            if (chars[i] > 0xff)
+                return NULL;
+        }
+        search = cptr + 1;
+        while (s->cbuf_end - search >= char_count) {
+            p = memchr(search, chars[0],
+                       s->cbuf_end - search - char_count + 1);
+            if (!p)
+                return NULL;
+            for(i = 1; i < char_count; i++) {
+                if (p[i] != chars[i])
+                    break;
+            }
+            if (i == char_count)
+                return p - 1;
+            search = p + 1;
+        }
+        return NULL;
+    } else {
+        const uint16_t *p = (const uint16_t *)cptr + 1;
+        const uint16_t *end = (const uint16_t *)s->cbuf_end;
+        int count = 0;
+
+        while (end - p >= char_count) {
+            for(i = 0; i < char_count; i++) {
+                if (p[i] != chars[i])
+                    break;
+            }
+            if (i == char_count)
+                return (const uint8_t *)(p - 1);
+            p++;
+            if ((++count & 1023) == 0 && lre_poll_timeout(s)) {
+                *pret = LRE_RET_TIMEOUT;
+                return NULL;
+            }
+        }
+        return NULL;
+    }
+}
+
 /* Return 1 if match, 0 if not match or < 0 if error (see LRE_RET_x). cindex is the
    starting position of the match and must be such as 0 <= cindex <=
    clen. */
@@ -3814,7 +4010,10 @@ static int lre_exec_internal(uint8_t **capture, const uint8_t *bc_buf,
 {
     REExecContext s_s, *s = &s_s;
     int re_flags, i, ret;
-    const uint8_t *cptr;
+    uint32_t c, bytecode_len, filter_chars[4];
+    const uint8_t *cptr, *pc;
+    int filter_char_count;
+    BOOL scan_candidates, filter_candidates;
 
     re_flags = lre_get_flags(bc_buf);
     s->is_unicode = (re_flags & (LRE_FLAG_UNICODE | LRE_FLAG_UNICODE_SETS)) != 0;
@@ -3830,9 +4029,6 @@ static int lre_exec_internal(uint8_t **capture, const uint8_t *bc_buf,
     s->stack_buf = s->static_stack_buf;
     s->stack_size = countof(s->static_stack_buf);
 
-    for(i = 0; i < s->capture_count * 2; i++)
-        capture[i] = NULL;
-
     cptr = cbuf + (cindex << cbuf_type);
     if (0 < cindex && cindex < clen && s->cbuf_type == 2) {
         const uint16_t *p = (const uint16_t *)cptr;
@@ -3841,8 +4037,37 @@ static int lre_exec_internal(uint8_t **capture, const uint8_t *bc_buf,
         }
     }
 
-    ret = lre_exec_backtrack(s, capture,
-                             bc_buf + RE_HEADER_LEN + bytecode_offset, cptr);
+    bytecode_len = get_u32(bc_buf + RE_HEADER_BYTECODE_LEN);
+    pc = bc_buf + RE_HEADER_LEN + bytecode_offset;
+    scan_candidates = bytecode_offset == 0 && bytecode_len >= 13 &&
+        pc[0] == REOP_split_goto_first && get_i32(pc + 1) == 6 &&
+        pc[5] == REOP_any && pc[6] == REOP_goto &&
+        get_i32(pc + 7) == -11 && pc[11] == REOP_save_start && pc[12] == 0;
+    if (scan_candidates)
+        pc += 11;
+    filter_candidates = scan_candidates &&
+        re_get_leading_char_filter(bc_buf, RE_HEADER_LEN + bytecode_len,
+                                   re_flags, filter_chars, &filter_char_count);
+
+    for(i = 0; i < s->capture_count * 2; i++)
+        capture[i] = NULL;
+    ret = 0;
+    for(;;) {
+        if (filter_candidates) {
+            cptr = lre_find_leading_char_candidate(s, cptr, filter_chars,
+                                                    filter_char_count, &ret);
+            if (!cptr)
+                break;
+        }
+        ret = lre_exec_backtrack(s, capture, pc, cptr);
+        if (ret != 0 || !scan_candidates || cptr >= s->cbuf_end)
+            break;
+        GET_CHAR(c, cptr, s->cbuf_end, s->cbuf_type);
+        if (lre_poll_timeout(s)) {
+            ret = LRE_RET_TIMEOUT;
+            break;
+        }
+    }
 
     if (s->stack_buf != s->static_stack_buf)
         lre_realloc(s->opaque, s->stack_buf, 0);

--- a/libregexp.c
+++ b/libregexp.c
@@ -61,10 +61,15 @@ typedef enum {
 /* must be large enough to have a negligible runtime cost and small
    enough to call the interrupt callback often. */
 #define INTERRUPT_COUNTER_INIT 10000
+#define LRE_SCAN_CHUNK_SIZE 65536
 
-#ifndef LRE_PREFIX_MIN_LENGTH
-#define LRE_PREFIX_MIN_LENGTH 3
+#ifndef LRE_EXEC_STATIC_STACK_SIZE
+#define LRE_EXEC_STATIC_STACK_SIZE 128
 #endif
+#if LRE_EXEC_STATIC_STACK_SIZE < 8 || LRE_EXEC_STATIC_STACK_SIZE > 1024
+#error "LRE_EXEC_STATIC_STACK_SIZE must be between 8 and 1024"
+#endif
+
 #ifndef LRE_QUICK_CHECK_MIN_COUNT
 #define LRE_QUICK_CHECK_MIN_COUNT 3
 #endif
@@ -159,6 +164,24 @@ int lre_is_raw_atom(const char *buf, size_t len, int re_flags)
     return TRUE;
 }
 
+static BOOL re_get_scan_entry(const uint8_t *bc_buf, size_t bc_buf_len,
+                              size_t *pentry_pos)
+{
+    const uint8_t *code;
+
+    if (bc_buf_len < RE_HEADER_LEN + 13)
+        return FALSE;
+    code = bc_buf + RE_HEADER_LEN;
+    if (code[0] != REOP_split_goto_first || get_i32(code + 1) != 6 ||
+        code[5] != REOP_any || code[6] != REOP_goto ||
+        get_i32(code + 7) != -11 || code[11] != REOP_save_start ||
+        code[12] != 0) {
+        return FALSE;
+    }
+    *pentry_pos = 11;
+    return TRUE;
+}
+
 static BOOL re_has_literal_body(const uint8_t *bc_buf, size_t bc_buf_len,
                                 int re_flags, int capture_count,
                                 size_t *pchar_pos, uint32_t *plength,
@@ -172,17 +195,12 @@ static BOOL re_has_literal_body(const uint8_t *bc_buf, size_t bc_buf_len,
     if (capture_count != 1 ||
         (re_flags & (LRE_FLAG_IGNORECASE | LRE_FLAG_STICKY |
                      LRE_FLAG_UNICODE | LRE_FLAG_UNICODE_SETS)) ||
-        bc_buf_len < RE_HEADER_LEN + 16) {
+        bc_buf_len < RE_HEADER_LEN + 16 ||
+        !re_get_scan_entry(bc_buf, bc_buf_len, &char_pos)) {
         return FALSE;
     }
     code = bc_buf + RE_HEADER_LEN;
     bc_buf_len -= RE_HEADER_LEN;
-    if (code[0] != REOP_split_goto_first || get_i32(code + 1) != 6 ||
-        code[5] != REOP_any || code[6] != REOP_goto ||
-        get_i32(code + 7) != -11 || code[11] != REOP_save_start ||
-        code[12] != 0) {
-        return FALSE;
-    }
 
     pos = char_pos = 13;
     length = 0;
@@ -232,17 +250,12 @@ static BOOL re_get_linear_prefix(const uint8_t *bc_buf, size_t bc_buf_len,
 
     if ((re_flags & (LRE_FLAG_IGNORECASE | LRE_FLAG_STICKY |
                      LRE_FLAG_UNICODE | LRE_FLAG_UNICODE_SETS)) ||
-        bc_buf_len < RE_HEADER_LEN + 16) {
+        bc_buf_len < RE_HEADER_LEN + 16 ||
+        !re_get_scan_entry(bc_buf, bc_buf_len, &pos)) {
         return FALSE;
     }
     code = bc_buf + RE_HEADER_LEN;
     bc_buf_len -= RE_HEADER_LEN;
-    if (code[0] != REOP_split_goto_first || get_i32(code + 1) != 6 ||
-        code[5] != REOP_any || code[6] != REOP_goto ||
-        get_i32(code + 7) != -11 || code[11] != REOP_save_start ||
-        code[12] != 0) {
-        return FALSE;
-    }
 
     pos = 13;
     if (code[pos] == REOP_split_goto_first ||
@@ -328,14 +341,22 @@ static BOOL re_get_linear_prefix(const uint8_t *bc_buf, size_t bc_buf_len,
 
 static int re_append_metadata(REParseState *s, int kind, size_t entry_pos,
                               size_t char_pos, uint32_t length, int encoding,
-                              int metadata_flags)
+                              int metadata_flags, uint32_t exec_flags,
+                              const uint32_t *leading_chars,
+                              int leading_count)
 {
     uint8_t header[LRE_META_HEADER_LEN];
-    size_t pos, code_len;
+    size_t payload_size, primary_payload_size, pos, code_len;
+    int i;
     uint32_t c;
 
-    if (entry_pos > UINT32_MAX ||
+    if (leading_count < 0 || leading_count > LRE_META_LEADING_MAX ||
         (encoding && length > UINT32_MAX / 2))
+        return 0;
+    primary_payload_size = (metadata_flags & LRE_META_FLAG_SOURCE) ? 0 :
+        (size_t)length << encoding;
+    payload_size = primary_payload_size + (size_t)leading_count * 4;
+    if (entry_pos > UINT32_MAX || payload_size > UINT32_MAX)
         return 0;
     code_len = get_u32(s->byte_code.buf + RE_HEADER_BYTECODE_LEN);
     memset(header, 0, sizeof(header));
@@ -343,15 +364,17 @@ static int re_append_metadata(REParseState *s, int kind, size_t entry_pos,
     header[LRE_META_KIND_OFFSET] = kind;
     header[LRE_META_ENCODING_OFFSET] = encoding;
     header[LRE_META_FLAGS_OFFSET] = metadata_flags;
-    put_u32(header + LRE_META_PAYLOAD_SIZE_OFFSET, length << encoding);
+    put_u32(header + LRE_META_PAYLOAD_SIZE_OFFSET, payload_size);
     put_u32(header + LRE_META_LENGTH_OFFSET, length);
     put_u32(header + LRE_META_ENTRY_OFFSET, entry_pos);
+    put_u32(header + LRE_META_EXEC_FLAGS_OFFSET, exec_flags);
+    put_u32(header + LRE_META_LEADING_COUNT_OFFSET, leading_count);
     dbuf_put(&s->byte_code, header, sizeof(header));
     if (dbuf_error(&s->byte_code))
         return -1;
 
     pos = char_pos;
-    while (pos < code_len) {
+    while (primary_payload_size != 0 && pos < code_len) {
         if (s->byte_code.buf[RE_HEADER_LEN + pos] == REOP_char) {
             c = get_u16(s->byte_code.buf + RE_HEADER_LEN + pos + 1);
             pos += 3;
@@ -368,13 +391,18 @@ static int re_append_metadata(REParseState *s, int kind, size_t entry_pos,
         if (--length == 0)
             break;
     }
+    for(i = 0; i < leading_count; i++)
+        dbuf_put_u32(&s->byte_code, leading_chars[i]);
     put_u16(s->byte_code.buf + RE_HEADER_FLAGS,
             lre_get_flags(s->byte_code.buf) | LRE_FLAG_HAS_META);
     return dbuf_error(&s->byte_code) ? -1 : 1;
 }
 
 static int re_append_literal_metadata(REParseState *s, int re_flags,
-                                      BOOL payload_matches_source)
+                                      BOOL payload_matches_source,
+                                      uint32_t exec_flags,
+                                      const uint32_t *leading_chars,
+                                      int leading_count)
 {
     size_t char_pos;
     uint32_t length;
@@ -386,9 +414,12 @@ static int re_append_literal_metadata(REParseState *s, int re_flags,
                              &encoding)) {
         return 0;
     }
+    if (!payload_matches_source && length > LRE_LITERAL_MAX_LENGTH)
+        return 0;
     if (re_append_metadata(s, LRE_META_LITERAL, 11, char_pos, length,
                            encoding, payload_matches_source ?
-                           LRE_META_FLAG_SOURCE : 0) < 0)
+                           LRE_META_FLAG_SOURCE : 0, exec_flags,
+                           leading_chars, leading_count) < 0)
         return -1;
     put_u16(s->byte_code.buf + RE_HEADER_FLAGS,
             lre_get_flags(s->byte_code.buf) |
@@ -396,10 +427,13 @@ static int re_append_literal_metadata(REParseState *s, int re_flags,
     return 1;
 }
 
-static int re_append_prefix_metadata(REParseState *s, int re_flags)
+static int re_append_prefix_metadata(REParseState *s, int re_flags,
+                                     uint32_t exec_flags,
+                                     const uint32_t *leading_chars,
+                                     int leading_count)
 {
-    size_t entry_pos, char_pos, code_len;
-    uint32_t length;
+    size_t entry_pos, char_pos, code_len, pos;
+    uint32_t c, i, length;
     int encoding;
 
     code_len = get_u32(s->byte_code.buf + RE_HEADER_BYTECODE_LEN);
@@ -408,8 +442,25 @@ static int re_append_prefix_metadata(REParseState *s, int re_flags)
                               &encoding) || length < LRE_PREFIX_MIN_LENGTH) {
         return 0;
     }
+    if (length > LRE_PREFIX_MAX_LENGTH) {
+        length = LRE_PREFIX_MAX_LENGTH;
+        encoding = 0;
+        pos = char_pos;
+        for(i = 0; i < length; i++) {
+            if (s->byte_code.buf[RE_HEADER_LEN + pos] == REOP_char) {
+                c = get_u16(s->byte_code.buf + RE_HEADER_LEN + pos + 1);
+                pos += 3;
+            } else {
+                c = get_u32(s->byte_code.buf + RE_HEADER_LEN + pos + 1);
+                pos += 5;
+            }
+            if (c > 0xff)
+                encoding = 1;
+        }
+    }
     return re_append_metadata(s, LRE_META_PREFIX, entry_pos, char_pos,
-                              length, encoding, 0);
+                              length, encoding, 0, exec_flags,
+                              leading_chars, leading_count);
 }
 
 static BOOL re_get_quick_checks(const uint8_t *bc_buf, size_t bc_buf_len,
@@ -426,17 +477,12 @@ static BOOL re_get_quick_checks(const uint8_t *bc_buf, size_t bc_buf_len,
 
     if ((re_flags & (LRE_FLAG_IGNORECASE | LRE_FLAG_STICKY |
                      LRE_FLAG_UNICODE | LRE_FLAG_UNICODE_SETS)) ||
-        bc_buf_len < RE_HEADER_LEN + 16) {
+        bc_buf_len < RE_HEADER_LEN + 16 ||
+        !re_get_scan_entry(bc_buf, bc_buf_len, &pos)) {
         return FALSE;
     }
     code = bc_buf + RE_HEADER_LEN;
     bc_buf_len -= RE_HEADER_LEN;
-    if (code[0] != REOP_split_goto_first || get_i32(code + 1) != 6 ||
-        code[5] != REOP_any || code[6] != REOP_goto ||
-        get_i32(code + 7) != -11 || code[11] != REOP_save_start ||
-        code[12] != 0) {
-        return FALSE;
-    }
 
     pos = 13;
     count = 0;
@@ -503,7 +549,10 @@ static BOOL re_get_quick_checks(const uint8_t *bc_buf, size_t bc_buf_len,
     return TRUE;
 }
 
-static int re_append_quick_check_metadata(REParseState *s, int re_flags)
+static int re_append_quick_check_metadata(REParseState *s, int re_flags,
+                                          uint32_t exec_flags,
+                                          const uint32_t *leading_chars,
+                                          int leading_count)
 {
     uint8_t header[LRE_META_HEADER_LEN];
     uint16_t offsets[LRE_QUICK_CHECK_MAX];
@@ -522,15 +571,19 @@ static int re_append_quick_check_metadata(REParseState *s, int re_flags)
     header[LRE_META_VERSION_OFFSET] = LRE_META_VERSION;
     header[LRE_META_KIND_OFFSET] = LRE_META_QUICK_CHECK;
     put_u32(header + LRE_META_PAYLOAD_SIZE_OFFSET,
-            count * LRE_QUICK_CHECK_RECORD_SIZE);
+            count * LRE_QUICK_CHECK_RECORD_SIZE + leading_count * 4);
     put_u32(header + LRE_META_LENGTH_OFFSET, count);
     put_u32(header + LRE_META_ENTRY_OFFSET, entry_pos);
+    put_u32(header + LRE_META_EXEC_FLAGS_OFFSET, exec_flags);
+    put_u32(header + LRE_META_LEADING_COUNT_OFFSET, leading_count);
     dbuf_put(&s->byte_code, header, sizeof(header));
     for(i = 0; i < count; i++) {
         dbuf_put_u16(&s->byte_code, offsets[i]);
         dbuf_put_u16(&s->byte_code, values[i]);
         dbuf_put_u16(&s->byte_code, masks[i]);
     }
+    for(i = 0; i < leading_count; i++)
+        dbuf_put_u32(&s->byte_code, leading_chars[i]);
     put_u16(s->byte_code.buf + RE_HEADER_FLAGS,
             lre_get_flags(s->byte_code.buf) | LRE_FLAG_HAS_META);
     return dbuf_error(&s->byte_code) ? -1 : 1;
@@ -594,15 +647,11 @@ static BOOL re_get_leading_char_filter(const uint8_t *bc_buf,
                     LRE_FLAG_STICKY | LRE_FLAG_UNICODE |
                     LRE_FLAG_UNICODE_SETS))
         return FALSE;
-    if (bc_buf_len < RE_HEADER_LEN + 20)
+    if (bc_buf_len < RE_HEADER_LEN + 20 ||
+        !re_get_scan_entry(bc_buf, bc_buf_len, &pos))
         return FALSE;
     code = bc_buf + RE_HEADER_LEN;
     bc_buf_len -= RE_HEADER_LEN;
-    if (code[0] != REOP_split_goto_first || get_i32(code + 1) != 6 ||
-        code[5] != REOP_any || code[6] != REOP_goto ||
-        get_i32(code + 7) != -11 || code[11] != REOP_save_start ||
-        code[12] != 0)
-        return FALSE;
 
     pos = 13;
     capture_index = -1;
@@ -633,7 +682,7 @@ static BOOL re_get_leading_char_filter(const uint8_t *bc_buf,
         pos += 2;
     }
     char_count = 0;
-    while (pos < bc_buf_len && char_count < 4) {
+    while (pos < bc_buf_len && char_count < LRE_META_LEADING_MAX) {
         opcode = code[pos];
         if (opcode == REOP_char) {
             if (pos + 3 > bc_buf_len)
@@ -662,8 +711,8 @@ static int lre_parse_metadata(const uint8_t *bc_buf, size_t bc_buf_len,
                               LREMetadata *meta, const uint8_t **ptrailer)
 {
     const uint8_t *p, *end;
-    size_t code_len;
-    uint32_t payload_size;
+    size_t code_len, leading_size;
+    uint32_t exec_flags, leading_count, payload_size;
     int flags;
 
     if (meta)
@@ -683,23 +732,32 @@ static int lre_parse_metadata(const uint8_t *bc_buf, size_t bc_buf_len,
     }
     if ((size_t)(end - p) < LRE_META_HEADER_LEN ||
         p[LRE_META_VERSION_OFFSET] != LRE_META_VERSION ||
-        p[LRE_META_KIND_OFFSET] <= LRE_META_NONE ||
         p[LRE_META_KIND_OFFSET] > LRE_META_QUICK_CHECK ||
         p[LRE_META_ENCODING_OFFSET] > 1 ||
         (p[LRE_META_FLAGS_OFFSET] & ~LRE_META_FLAG_SOURCE)) {
         return -1;
     }
     payload_size = get_u32(p + LRE_META_PAYLOAD_SIZE_OFFSET);
+    exec_flags = get_u32(p + LRE_META_EXEC_FLAGS_OFFSET);
+    leading_count = get_u32(p + LRE_META_LEADING_COUNT_OFFSET);
+    leading_size = (size_t)leading_count * 4;
     if (payload_size > (size_t)(end - p - LRE_META_HEADER_LEN))
+        return -1;
+    if (leading_count > LRE_META_LEADING_MAX ||
+        leading_size > payload_size)
         return -1;
     if (meta) {
         meta->kind = p[LRE_META_KIND_OFFSET];
         meta->encoding = p[LRE_META_ENCODING_OFFSET];
         meta->flags = p[LRE_META_FLAGS_OFFSET];
         meta->payload_size = payload_size;
+        meta->primary_payload_size = payload_size - leading_size;
         meta->length = get_u32(p + LRE_META_LENGTH_OFFSET);
         meta->entry_offset = get_u32(p + LRE_META_ENTRY_OFFSET);
+        meta->exec_flags = exec_flags;
+        meta->leading_count = leading_count;
         meta->payload = p + LRE_META_HEADER_LEN;
+        meta->leading_chars = meta->payload + meta->primary_payload_size;
     }
     if (ptrailer)
         *ptrailer = p + LRE_META_HEADER_LEN + payload_size;
@@ -3119,7 +3177,9 @@ uint8_t *lre_compile(int *plen, char *error_msg, int error_msg_size,
                      void *opaque)
 {
     REParseState s_s, *s = &s_s;
-    int register_count, metadata_result;
+    uint32_t exec_flags, leading_chars[LRE_META_LEADING_MAX];
+    size_t code_len, scan_entry;
+    int leading_count, register_count, metadata_result;
     BOOL is_sticky, payload_matches_source;
 
     memset(s, 0, sizeof(*s));
@@ -3189,14 +3249,43 @@ uint8_t *lre_compile(int *plen, char *error_msg, int error_msg_size,
 
     s->byte_code.buf[RE_HEADER_CAPTURE_COUNT] = s->capture_count;
     s->byte_code.buf[RE_HEADER_REGISTER_COUNT] = register_count;
-    put_u32(s->byte_code.buf + RE_HEADER_BYTECODE_LEN,
-            s->byte_code.size - RE_HEADER_LEN);
+    code_len = s->byte_code.size - RE_HEADER_LEN;
+    put_u32(s->byte_code.buf + RE_HEADER_BYTECODE_LEN, code_len);
+
+    exec_flags = 0;
+    leading_count = 0;
+    scan_entry = 0;
+    if (!is_sticky) {
+        if (!re_get_scan_entry(s->byte_code.buf, s->byte_code.size,
+                               &scan_entry)) {
+            re_parse_error(s, "internal regexp scan descriptor error");
+            goto error;
+        }
+        exec_flags |= LRE_META_EXEC_SCAN;
+        if (re_get_leading_char_filter(s->byte_code.buf, s->byte_code.size,
+                                       re_flags, leading_chars,
+                                       &leading_count)) {
+            exec_flags |= LRE_META_EXEC_LEADING;
+        }
+    }
     metadata_result = re_append_literal_metadata(s, re_flags,
-                                                 payload_matches_source);
+                                                 payload_matches_source,
+                                                 exec_flags, leading_chars,
+                                                 leading_count);
     if (metadata_result == 0)
-        metadata_result = re_append_prefix_metadata(s, re_flags);
+        metadata_result = re_append_prefix_metadata(s, re_flags, exec_flags,
+                                                    leading_chars,
+                                                    leading_count);
     if (metadata_result == 0)
-        metadata_result = re_append_quick_check_metadata(s, re_flags);
+        metadata_result = re_append_quick_check_metadata(s, re_flags,
+                                                         exec_flags,
+                                                         leading_chars,
+                                                         leading_count);
+    if (metadata_result == 0 && exec_flags != 0) {
+        metadata_result = re_append_metadata(s, LRE_META_NONE, scan_entry, 0,
+                                             0, 0, 0, exec_flags,
+                                             leading_chars, leading_count);
+    }
     if (metadata_result < 0) {
         re_parse_out_of_memory(s);
         goto error;
@@ -3340,7 +3429,9 @@ typedef struct {
 
     StackElem *stack_buf;
     size_t stack_size;
-    StackElem static_stack_buf[128]; /* static stack to avoid allocation in most cases */
+    /* One entry costs one pointer: 512 bytes on 32-bit and 1024 bytes on
+       64-bit targets with the default capacity. */
+    StackElem static_stack_buf[LRE_EXEC_STATIC_STACK_SIZE];
 } REExecContext;
 
 static int lre_poll_timeout(REExecContext *s)
@@ -3957,7 +4048,7 @@ static const uint8_t *lre_find_leading_char_candidate(REExecContext *s,
             return cptr;
     }
     if (s->cbuf_type == 0) {
-        const uint8_t *p, *search;
+        const uint8_t *chunk_end, *p, *search;
 
         for(i = 0; i < char_count; i++) {
             if (chars[i] > 0xff)
@@ -3965,33 +4056,49 @@ static const uint8_t *lre_find_leading_char_candidate(REExecContext *s,
         }
         search = cptr + 1;
         while (s->cbuf_end - search >= char_count) {
-            p = memchr(search, chars[0],
-                       s->cbuf_end - search - char_count + 1);
-            if (!p)
-                return NULL;
-            for(i = 1; i < char_count; i++) {
-                if (p[i] != chars[i])
+            size_t candidate_count = s->cbuf_end - search - char_count + 1;
+
+            chunk_end = search + min_int(candidate_count,
+                                         LRE_SCAN_CHUNK_SIZE);
+            while (search < chunk_end) {
+                p = memchr(search, chars[0], chunk_end - search);
+                if (!p)
                     break;
+                for(i = 1; i < char_count; i++) {
+                    if (p[i] != chars[i])
+                        break;
+                }
+                if (i == char_count)
+                    return p - 1;
+                search = p + 1;
             }
-            if (i == char_count)
-                return p - 1;
-            search = p + 1;
+            search = chunk_end;
+            if (s->cbuf_end - search >= char_count &&
+                lre_check_timeout(s->opaque)) {
+                *pret = LRE_RET_TIMEOUT;
+                return NULL;
+            }
         }
         return NULL;
     } else {
         const uint16_t *p = (const uint16_t *)cptr + 1;
         const uint16_t *end = (const uint16_t *)s->cbuf_end;
-        int count = 0;
 
         while (end - p >= char_count) {
-            for(i = 0; i < char_count; i++) {
-                if (p[i] != chars[i])
-                    break;
+            const uint16_t *chunk_end;
+            size_t candidate_count = end - p - char_count + 1;
+
+            chunk_end = p + min_int(candidate_count, LRE_SCAN_CHUNK_SIZE);
+            while (p < chunk_end) {
+                for(i = 0; i < char_count; i++) {
+                    if (p[i] != chars[i])
+                        break;
+                }
+                if (i == char_count)
+                    return (const uint8_t *)(p - 1);
+                p++;
             }
-            if (i == char_count)
-                return (const uint8_t *)(p - 1);
-            p++;
-            if ((++count & 1023) == 0 && lre_poll_timeout(s)) {
+            if (end - p >= char_count && lre_check_timeout(s->opaque)) {
                 *pret = LRE_RET_TIMEOUT;
                 return NULL;
             }
@@ -4010,8 +4117,8 @@ static int lre_exec_internal(uint8_t **capture, const uint8_t *bc_buf,
 {
     REExecContext s_s, *s = &s_s;
     int re_flags, i, ret;
-    uint32_t c, bytecode_len, filter_chars[4];
-    const uint8_t *cptr, *pc;
+    uint32_t c, bytecode_len, filter_chars[4], metadata_payload_size;
+    const uint8_t *cptr, *metadata, *pc;
     int filter_char_count;
     BOOL scan_candidates, filter_candidates;
 
@@ -4039,15 +4146,35 @@ static int lre_exec_internal(uint8_t **capture, const uint8_t *bc_buf,
 
     bytecode_len = get_u32(bc_buf + RE_HEADER_BYTECODE_LEN);
     pc = bc_buf + RE_HEADER_LEN + bytecode_offset;
-    scan_candidates = bytecode_offset == 0 && bytecode_len >= 13 &&
-        pc[0] == REOP_split_goto_first && get_i32(pc + 1) == 6 &&
-        pc[5] == REOP_any && pc[6] == REOP_goto &&
-        get_i32(pc + 7) == -11 && pc[11] == REOP_save_start && pc[12] == 0;
-    if (scan_candidates)
-        pc += 11;
-    filter_candidates = scan_candidates &&
-        re_get_leading_char_filter(bc_buf, RE_HEADER_LEN + bytecode_len,
-                                   re_flags, filter_chars, &filter_char_count);
+    /* Source bytecode is compiler-owned; serialized bytecode is validated
+       before it can reach the regexp runtime. */
+    metadata = bc_buf + RE_HEADER_LEN + bytecode_len;
+    scan_candidates = bytecode_offset == 0 &&
+        (re_flags & LRE_FLAG_HAS_META) &&
+        metadata[LRE_META_VERSION_OFFSET] == LRE_META_VERSION &&
+        (get_u32(metadata + LRE_META_EXEC_FLAGS_OFFSET) &
+         LRE_META_EXEC_SCAN);
+    filter_candidates = FALSE;
+    filter_char_count = 0;
+    if (scan_candidates) {
+        pc = bc_buf + RE_HEADER_LEN +
+            get_u32(metadata + LRE_META_ENTRY_OFFSET);
+        if (get_u32(metadata + LRE_META_EXEC_FLAGS_OFFSET) &
+            LRE_META_EXEC_LEADING) {
+            filter_char_count = get_u32(
+                metadata + LRE_META_LEADING_COUNT_OFFSET);
+            metadata_payload_size = get_u32(
+                metadata + LRE_META_PAYLOAD_SIZE_OFFSET);
+            if (filter_char_count <= LRE_META_LEADING_MAX &&
+                metadata_payload_size >= (uint32_t)filter_char_count * 4) {
+                metadata += LRE_META_HEADER_LEN + metadata_payload_size -
+                    filter_char_count * 4;
+                for(i = 0; i < filter_char_count; i++)
+                    filter_chars[i] = get_u32(metadata + i * 4);
+                filter_candidates = filter_char_count != 0;
+            }
+        }
+    }
 
     for(i = 0; i < s->capture_count * 2; i++)
         capture[i] = NULL;
@@ -4135,12 +4262,15 @@ int lre_validate_bytecode(const uint8_t *bc_buf, size_t bc_buf_len,
     uint8_t *insn_map, *lookahead_end;
     size_t code_len, pos, insn_len, target, prev_pos, char_pos, entry_pos;
     uint32_t value, low, high, previous_high, literal_length, c;
+    uint32_t metadata_index;
+    uint32_t leading_chars[LRE_META_LEADING_MAX];
     uint16_t quick_offsets[LRE_QUICK_CHECK_MAX];
     uint16_t quick_values[LRE_QUICK_CHECK_MAX];
     uint16_t quick_masks[LRE_QUICK_CHECK_MAX];
     int flags, capture_count, register_count;
     int opcode, i, n, register_depth, register_max, literal_encoding;
-    int last_opcode, expected_terminal, metadata_status, quick_count;
+    int last_opcode, expected_terminal, leading_count;
+    int metadata_status, quick_count;
     LREMetadata metadata;
 
     if (error_msg_size > 0)
@@ -4181,24 +4311,80 @@ int lre_validate_bytecode(const uint8_t *bc_buf, size_t bc_buf_len,
     if (!!(flags & LRE_FLAG_HAS_META) != (metadata_status > 0))
         return lre_validation_error(error_msg, error_msg_size,
                                     "regexp metadata flag is inconsistent");
+    if (!(flags & LRE_FLAG_STICKY) && metadata_status <= 0)
+        return lre_validation_error(error_msg, error_msg_size,
+                                    "regexp scan descriptor is missing");
     if (metadata_status > 0) {
-        if (metadata.kind == LRE_META_LITERAL ||
-            metadata.kind == LRE_META_PREFIX) {
+        if (metadata.exec_flags & ~(LRE_META_EXEC_SCAN |
+                                    LRE_META_EXEC_LEADING)) {
+            return lre_validation_error(error_msg, error_msg_size,
+                                        "regexp execution flags are invalid");
+        }
+        if (!!(metadata.exec_flags & LRE_META_EXEC_SCAN) !=
+            !(flags & LRE_FLAG_STICKY) ||
+            ((metadata.exec_flags & LRE_META_EXEC_SCAN) &&
+             (!re_get_scan_entry(bc_buf, RE_HEADER_LEN + code_len,
+                                 &entry_pos) ||
+              entry_pos != metadata.entry_offset))) {
+            return lre_validation_error(error_msg, error_msg_size,
+                                        "regexp scan descriptor is inconsistent");
+        }
+        leading_count = 0;
+        if (re_get_leading_char_filter(bc_buf, RE_HEADER_LEN + code_len,
+                                       flags, leading_chars,
+                                       &leading_count)) {
+            if (!(metadata.exec_flags & LRE_META_EXEC_LEADING) ||
+                metadata.leading_count != (uint32_t)leading_count) {
+                return lre_validation_error(error_msg, error_msg_size,
+                                            "regexp leading descriptor is inconsistent");
+            }
+            for(i = 0; i < leading_count; i++) {
+                if (get_u32(metadata.leading_chars + i * 4) !=
+                    leading_chars[i]) {
+                    return lre_validation_error(
+                        error_msg, error_msg_size,
+                        "regexp leading payload is inconsistent");
+                }
+            }
+        } else if ((metadata.exec_flags & LRE_META_EXEC_LEADING) ||
+                   metadata.leading_count != 0) {
+            return lre_validation_error(error_msg, error_msg_size,
+                                        "regexp leading descriptor is invalid");
+        }
+
+        if (metadata.kind == LRE_META_NONE) {
+            if (metadata.flags != 0 || metadata.encoding != 0 ||
+                metadata.length != 0 || metadata.primary_payload_size != 0) {
+                return lre_validation_error(error_msg, error_msg_size,
+                                            "regexp empty metadata is invalid");
+            }
+        } else if (metadata.kind == LRE_META_LITERAL) {
             if (metadata.length == 0 ||
-                metadata.length > UINT32_MAX >> metadata.encoding ||
-                metadata.payload_size !=
-                    (metadata.length << metadata.encoding)) {
+                (metadata.flags & ~LRE_META_FLAG_SOURCE) != 0 ||
+                ((metadata.flags & LRE_META_FLAG_SOURCE) ?
+                 metadata.primary_payload_size != 0 :
+                 (metadata.length > LRE_LITERAL_MAX_LENGTH ||
+                  metadata.length > UINT32_MAX >> metadata.encoding ||
+                  metadata.primary_payload_size !=
+                      (metadata.length << metadata.encoding)))) {
                 return lre_validation_error(error_msg, error_msg_size,
                                             "regexp literal metadata is invalid");
             }
-            if (metadata.kind == LRE_META_PREFIX && metadata.flags != 0)
+        } else if (metadata.kind == LRE_META_PREFIX) {
+            if (metadata.flags != 0 ||
+                metadata.length < LRE_PREFIX_MIN_LENGTH ||
+                metadata.length > LRE_PREFIX_MAX_LENGTH ||
+                metadata.length > UINT32_MAX >> metadata.encoding ||
+                metadata.primary_payload_size !=
+                    (metadata.length << metadata.encoding)) {
                 return lre_validation_error(error_msg, error_msg_size,
-                                            "regexp prefix flags are invalid");
+                                            "regexp prefix metadata is invalid");
+            }
         } else {
             if (metadata.flags != 0 || metadata.encoding != 0 ||
                 metadata.length < 3 ||
                 metadata.length > LRE_QUICK_CHECK_MAX ||
-                metadata.payload_size !=
+                metadata.primary_payload_size !=
                     metadata.length * LRE_QUICK_CHECK_RECORD_SIZE) {
                 return lre_validation_error(error_msg, error_msg_size,
                                             "regexp quick-check metadata is invalid");
@@ -4239,14 +4425,19 @@ int lre_validate_bytecode(const uint8_t *bc_buf, size_t bc_buf_len,
                 bc_buf, RE_HEADER_LEN + code_len, flags, &entry_pos,
                 &char_pos, &literal_length, &literal_encoding);
         }
+        if (metadata.kind == LRE_META_PREFIX &&
+            literal_length > LRE_PREFIX_MAX_LENGTH) {
+            literal_length = LRE_PREFIX_MAX_LENGTH;
+        }
         if (!metadata_matches || literal_length != metadata.length ||
-            literal_encoding != metadata.encoding ||
             entry_pos != metadata.entry_offset) {
             return lre_validation_error(error_msg, error_msg_size,
                                         "regexp optimization metadata is inconsistent");
         }
         pos = char_pos;
-        for(i = 0; i < (int)literal_length; i++) {
+        literal_encoding = 0;
+        for(metadata_index = 0; metadata_index < literal_length;
+            metadata_index++) {
             if (code[pos] == REOP_char) {
                 c = get_u16(code + pos + 1);
                 pos += 3;
@@ -4254,13 +4445,19 @@ int lre_validate_bytecode(const uint8_t *bc_buf, size_t bc_buf_len,
                 c = get_u32(code + pos + 1);
                 pos += 5;
             }
-            if (c != (metadata.encoding ?
-                      get_u16(metadata.payload + i * 2) :
-                      metadata.payload[i])) {
+            if (c > 0xff)
+                literal_encoding = 1;
+            if (!(metadata.flags & LRE_META_FLAG_SOURCE) &&
+                c != (metadata.encoding ?
+                      get_u16(metadata.payload + metadata_index * 2) :
+                      metadata.payload[metadata_index])) {
                 return lre_validation_error(error_msg, error_msg_size,
                                             "regexp metadata payload is inconsistent");
             }
         }
+        if (literal_encoding != metadata.encoding)
+            return lre_validation_error(error_msg, error_msg_size,
+                                        "regexp metadata encoding is inconsistent");
     } else if (metadata_status > 0 &&
                metadata.kind == LRE_META_QUICK_CHECK) {
         if (!re_get_quick_checks(bc_buf, RE_HEADER_LEN + code_len, flags,

--- a/libregexp.c
+++ b/libregexp.c
@@ -62,6 +62,13 @@ typedef enum {
    enough to call the interrupt callback often. */
 #define INTERRUPT_COUNTER_INIT 10000
 
+#ifndef LRE_PREFIX_MIN_LENGTH
+#define LRE_PREFIX_MIN_LENGTH 3
+#endif
+#ifndef LRE_QUICK_CHECK_MIN_COUNT
+#define LRE_QUICK_CHECK_MIN_COUNT 3
+#endif
+
 /* unicode code points */
 #define CP_LS   0x2028
 #define CP_PS   0x2029
@@ -117,6 +124,472 @@ static const REOpCode reopcode_info[REOP_COUNT] = {
 
 static inline int is_digit(int c) {
     return c >= '0' && c <= '9';
+}
+
+int lre_is_raw_atom(const char *buf, size_t len, int re_flags)
+{
+    size_t i;
+
+    if (len == 0 ||
+        (re_flags & (LRE_FLAG_IGNORECASE | LRE_FLAG_STICKY |
+                     LRE_FLAG_UNICODE | LRE_FLAG_UNICODE_SETS))) {
+        return FALSE;
+    }
+    for (i = 0; i < len; i++) {
+        switch ((uint8_t)buf[i]) {
+        case '\\':
+        case '^':
+        case '$':
+        case '.':
+        case '*':
+        case '+':
+        case '?':
+        case '(':
+        case ')':
+        case '[':
+        case ']':
+        case '{':
+        case '}':
+        case '|':
+            return FALSE;
+        default:
+            break;
+        }
+    }
+    return TRUE;
+}
+
+static BOOL re_has_literal_body(const uint8_t *bc_buf, size_t bc_buf_len,
+                                int re_flags, int capture_count,
+                                size_t *pchar_pos, uint32_t *plength,
+                                int *pencoding)
+{
+    const uint8_t *code;
+    size_t pos, char_pos;
+    uint32_t length, c;
+    int encoding;
+
+    if (capture_count != 1 ||
+        (re_flags & (LRE_FLAG_IGNORECASE | LRE_FLAG_STICKY |
+                     LRE_FLAG_UNICODE | LRE_FLAG_UNICODE_SETS)) ||
+        bc_buf_len < RE_HEADER_LEN + 16) {
+        return FALSE;
+    }
+    code = bc_buf + RE_HEADER_LEN;
+    bc_buf_len -= RE_HEADER_LEN;
+    if (code[0] != REOP_split_goto_first || get_i32(code + 1) != 6 ||
+        code[5] != REOP_any || code[6] != REOP_goto ||
+        get_i32(code + 7) != -11 || code[11] != REOP_save_start ||
+        code[12] != 0) {
+        return FALSE;
+    }
+
+    pos = char_pos = 13;
+    length = 0;
+    encoding = 0;
+    while (pos < bc_buf_len) {
+        if (code[pos] == REOP_char) {
+            if (pos + 3 > bc_buf_len)
+                return FALSE;
+            c = get_u16(code + pos + 1);
+            pos += 3;
+        } else if (code[pos] == REOP_char32) {
+            if (pos + 5 > bc_buf_len)
+                return FALSE;
+            c = get_u32(code + pos + 1);
+            if (c > 0xffff)
+                return FALSE;
+            pos += 5;
+        } else {
+            break;
+        }
+        if (c > 0xff)
+            encoding = 1;
+        if (length == UINT32_MAX)
+            return FALSE;
+        length++;
+    }
+    if (length == 0 || pos + 3 != bc_buf_len ||
+        code[pos] != REOP_save_end || code[pos + 1] != 0 ||
+        code[pos + 2] != REOP_match) {
+        return FALSE;
+    }
+    *pchar_pos = char_pos;
+    *plength = length;
+    *pencoding = encoding;
+    return TRUE;
+}
+
+static BOOL re_get_linear_prefix(const uint8_t *bc_buf, size_t bc_buf_len,
+                                 int re_flags, size_t *pentry_pos,
+                                 size_t *pchar_pos, uint32_t *plength,
+                                 int *pencoding)
+{
+    const uint8_t *code;
+    size_t pos, pos1, pos2, target;
+    uint32_t length, c, c1, c2;
+    int encoding;
+
+    if ((re_flags & (LRE_FLAG_IGNORECASE | LRE_FLAG_STICKY |
+                     LRE_FLAG_UNICODE | LRE_FLAG_UNICODE_SETS)) ||
+        bc_buf_len < RE_HEADER_LEN + 16) {
+        return FALSE;
+    }
+    code = bc_buf + RE_HEADER_LEN;
+    bc_buf_len -= RE_HEADER_LEN;
+    if (code[0] != REOP_split_goto_first || get_i32(code + 1) != 6 ||
+        code[5] != REOP_any || code[6] != REOP_goto ||
+        get_i32(code + 7) != -11 || code[11] != REOP_save_start ||
+        code[12] != 0) {
+        return FALSE;
+    }
+
+    pos = 13;
+    if (code[pos] == REOP_split_goto_first ||
+        code[pos] == REOP_split_next_first) {
+        if (pos + 5 > bc_buf_len)
+            return FALSE;
+        target = pos + 5 + get_i32(code + pos + 1);
+        if (target >= bc_buf_len)
+            return FALSE;
+        pos1 = pos + 5;
+        pos2 = target;
+        length = 0;
+        encoding = 0;
+        for (;;) {
+            if (pos1 >= bc_buf_len || pos2 >= bc_buf_len)
+                break;
+            if (code[pos1] == REOP_char && pos1 + 3 <= bc_buf_len) {
+                c1 = get_u16(code + pos1 + 1);
+                pos1 += 3;
+            } else if (code[pos1] == REOP_char32 &&
+                       pos1 + 5 <= bc_buf_len) {
+                c1 = get_u32(code + pos1 + 1);
+                pos1 += 5;
+            } else {
+                break;
+            }
+            if (code[pos2] == REOP_char && pos2 + 3 <= bc_buf_len) {
+                c2 = get_u16(code + pos2 + 1);
+                pos2 += 3;
+            } else if (code[pos2] == REOP_char32 &&
+                       pos2 + 5 <= bc_buf_len) {
+                c2 = get_u32(code + pos2 + 1);
+                pos2 += 5;
+            } else {
+                break;
+            }
+            if (c1 != c2 || c1 > 0xffff)
+                break;
+            if (c1 > 0xff)
+                encoding = 1;
+            length++;
+        }
+        if (length == 0)
+            return FALSE;
+        *pentry_pos = 11;
+        *pchar_pos = 18;
+        *plength = length;
+        *pencoding = encoding;
+        return TRUE;
+    }
+    length = 0;
+    encoding = 0;
+    while (pos < bc_buf_len) {
+        if (code[pos] == REOP_char) {
+            if (pos + 3 > bc_buf_len)
+                return FALSE;
+            c = get_u16(code + pos + 1);
+            pos += 3;
+        } else if (code[pos] == REOP_char32) {
+            if (pos + 5 > bc_buf_len)
+                return FALSE;
+            c = get_u32(code + pos + 1);
+            if (c > 0xffff)
+                return FALSE;
+            pos += 5;
+        } else {
+            break;
+        }
+        if (c > 0xff)
+            encoding = 1;
+        if (length == UINT32_MAX)
+            return FALSE;
+        length++;
+    }
+    if (length == 0)
+        return FALSE;
+    *pentry_pos = 11;
+    *pchar_pos = 13;
+    *plength = length;
+    *pencoding = encoding;
+    return TRUE;
+}
+
+static int re_append_metadata(REParseState *s, int kind, size_t entry_pos,
+                              size_t char_pos, uint32_t length, int encoding,
+                              int metadata_flags)
+{
+    uint8_t header[LRE_META_HEADER_LEN];
+    size_t pos, code_len;
+    uint32_t c;
+
+    if (entry_pos > UINT32_MAX ||
+        (encoding && length > UINT32_MAX / 2))
+        return 0;
+    code_len = get_u32(s->byte_code.buf + RE_HEADER_BYTECODE_LEN);
+    memset(header, 0, sizeof(header));
+    header[LRE_META_VERSION_OFFSET] = LRE_META_VERSION;
+    header[LRE_META_KIND_OFFSET] = kind;
+    header[LRE_META_ENCODING_OFFSET] = encoding;
+    header[LRE_META_FLAGS_OFFSET] = metadata_flags;
+    put_u32(header + LRE_META_PAYLOAD_SIZE_OFFSET, length << encoding);
+    put_u32(header + LRE_META_LENGTH_OFFSET, length);
+    put_u32(header + LRE_META_ENTRY_OFFSET, entry_pos);
+    dbuf_put(&s->byte_code, header, sizeof(header));
+    if (dbuf_error(&s->byte_code))
+        return -1;
+
+    pos = char_pos;
+    while (pos < code_len) {
+        if (s->byte_code.buf[RE_HEADER_LEN + pos] == REOP_char) {
+            c = get_u16(s->byte_code.buf + RE_HEADER_LEN + pos + 1);
+            pos += 3;
+        } else if (s->byte_code.buf[RE_HEADER_LEN + pos] == REOP_char32) {
+            c = get_u32(s->byte_code.buf + RE_HEADER_LEN + pos + 1);
+            pos += 5;
+        } else {
+            break;
+        }
+        if (encoding)
+            dbuf_put_u16(&s->byte_code, c);
+        else
+            dbuf_putc(&s->byte_code, c);
+        if (--length == 0)
+            break;
+    }
+    put_u16(s->byte_code.buf + RE_HEADER_FLAGS,
+            lre_get_flags(s->byte_code.buf) | LRE_FLAG_HAS_META);
+    return dbuf_error(&s->byte_code) ? -1 : 1;
+}
+
+static int re_append_literal_metadata(REParseState *s, int re_flags,
+                                      BOOL payload_matches_source)
+{
+    size_t char_pos;
+    uint32_t length;
+    int encoding;
+
+    size_t code_len = get_u32(s->byte_code.buf + RE_HEADER_BYTECODE_LEN);
+    if (!re_has_literal_body(s->byte_code.buf, RE_HEADER_LEN + code_len,
+                             re_flags, s->capture_count, &char_pos, &length,
+                             &encoding)) {
+        return 0;
+    }
+    if (re_append_metadata(s, LRE_META_LITERAL, 11, char_pos, length,
+                           encoding, payload_matches_source ?
+                           LRE_META_FLAG_SOURCE : 0) < 0)
+        return -1;
+    put_u16(s->byte_code.buf + RE_HEADER_FLAGS,
+            lre_get_flags(s->byte_code.buf) |
+            LRE_FLAG_ATOM);
+    return 1;
+}
+
+static int re_append_prefix_metadata(REParseState *s, int re_flags)
+{
+    size_t entry_pos, char_pos, code_len;
+    uint32_t length;
+    int encoding;
+
+    code_len = get_u32(s->byte_code.buf + RE_HEADER_BYTECODE_LEN);
+    if (!re_get_linear_prefix(s->byte_code.buf, RE_HEADER_LEN + code_len,
+                              re_flags, &entry_pos, &char_pos, &length,
+                              &encoding) || length < LRE_PREFIX_MIN_LENGTH) {
+        return 0;
+    }
+    return re_append_metadata(s, LRE_META_PREFIX, entry_pos, char_pos,
+                              length, encoding, 0);
+}
+
+static BOOL re_get_quick_checks(const uint8_t *bc_buf, size_t bc_buf_len,
+                                int re_flags, uint16_t *offsets,
+                                uint16_t *values, uint16_t *masks,
+                                int *pcount, size_t *pentry_pos)
+{
+    const uint8_t *code;
+    size_t pos;
+    uint32_t c, diff, low, high, range_mask, range_value;
+    uint32_t check_mask, check_value;
+    int count, consumed, i, n;
+    BOOL first;
+
+    if ((re_flags & (LRE_FLAG_IGNORECASE | LRE_FLAG_STICKY |
+                     LRE_FLAG_UNICODE | LRE_FLAG_UNICODE_SETS)) ||
+        bc_buf_len < RE_HEADER_LEN + 16) {
+        return FALSE;
+    }
+    code = bc_buf + RE_HEADER_LEN;
+    bc_buf_len -= RE_HEADER_LEN;
+    if (code[0] != REOP_split_goto_first || get_i32(code + 1) != 6 ||
+        code[5] != REOP_any || code[6] != REOP_goto ||
+        get_i32(code + 7) != -11 || code[11] != REOP_save_start ||
+        code[12] != 0) {
+        return FALSE;
+    }
+
+    pos = 13;
+    count = 0;
+    for(consumed = 0; consumed < LRE_QUICK_CHECK_MAX; consumed++) {
+        check_mask = 0;
+        check_value = 0;
+        if (pos < bc_buf_len && code[pos] == REOP_char) {
+            if (pos + 3 > bc_buf_len)
+                return FALSE;
+            check_mask = 0xffff;
+            check_value = get_u16(code + pos + 1);
+            pos += 3;
+        } else if (pos < bc_buf_len && code[pos] == REOP_char32) {
+            if (pos + 5 > bc_buf_len)
+                return FALSE;
+            c = get_u32(code + pos + 1);
+            if (c > 0xffff)
+                break;
+            check_mask = 0xffff;
+            check_value = c;
+            pos += 5;
+        } else if (pos < bc_buf_len && code[pos] == REOP_range) {
+            if (pos + 3 > bc_buf_len)
+                return FALSE;
+            n = get_u16(code + pos + 1);
+            if (n == 0 || (size_t)n > (bc_buf_len - pos - 3) / 4)
+                return FALSE;
+            first = TRUE;
+            for(i = 0; i < n; i++) {
+                low = get_u16(code + pos + 3 + i * 4);
+                high = get_u16(code + pos + 5 + i * 4);
+                diff = low ^ high;
+                range_mask = 0xffff;
+                while (diff) {
+                    range_mask = (range_mask << 1) & 0xffff;
+                    diff >>= 1;
+                }
+                range_value = low & range_mask;
+                if (first) {
+                    check_mask = range_mask;
+                    check_value = range_value;
+                    first = FALSE;
+                } else {
+                    check_mask &= range_mask;
+                    check_mask &= ~(check_value ^ range_value);
+                    check_value &= check_mask;
+                }
+            }
+            pos += 3 + (size_t)n * 4;
+        } else {
+            break;
+        }
+        if (check_mask != 0) {
+            offsets[count] = consumed;
+            values[count] = check_value;
+            masks[count] = check_mask;
+            count++;
+        }
+    }
+    if (count < LRE_QUICK_CHECK_MIN_COUNT)
+        return FALSE;
+    *pcount = count;
+    *pentry_pos = 11;
+    return TRUE;
+}
+
+static int re_append_quick_check_metadata(REParseState *s, int re_flags)
+{
+    uint8_t header[LRE_META_HEADER_LEN];
+    uint16_t offsets[LRE_QUICK_CHECK_MAX];
+    uint16_t values[LRE_QUICK_CHECK_MAX];
+    uint16_t masks[LRE_QUICK_CHECK_MAX];
+    size_t code_len, entry_pos;
+    int count, i;
+
+    code_len = get_u32(s->byte_code.buf + RE_HEADER_BYTECODE_LEN);
+    if (!re_get_quick_checks(s->byte_code.buf, RE_HEADER_LEN + code_len,
+                             re_flags, offsets, values, masks, &count,
+                             &entry_pos)) {
+        return 0;
+    }
+    memset(header, 0, sizeof(header));
+    header[LRE_META_VERSION_OFFSET] = LRE_META_VERSION;
+    header[LRE_META_KIND_OFFSET] = LRE_META_QUICK_CHECK;
+    put_u32(header + LRE_META_PAYLOAD_SIZE_OFFSET,
+            count * LRE_QUICK_CHECK_RECORD_SIZE);
+    put_u32(header + LRE_META_LENGTH_OFFSET, count);
+    put_u32(header + LRE_META_ENTRY_OFFSET, entry_pos);
+    dbuf_put(&s->byte_code, header, sizeof(header));
+    for(i = 0; i < count; i++) {
+        dbuf_put_u16(&s->byte_code, offsets[i]);
+        dbuf_put_u16(&s->byte_code, values[i]);
+        dbuf_put_u16(&s->byte_code, masks[i]);
+    }
+    put_u16(s->byte_code.buf + RE_HEADER_FLAGS,
+            lre_get_flags(s->byte_code.buf) | LRE_FLAG_HAS_META);
+    return dbuf_error(&s->byte_code) ? -1 : 1;
+}
+
+static int lre_parse_metadata(const uint8_t *bc_buf, size_t bc_buf_len,
+                              LREMetadata *meta, const uint8_t **ptrailer)
+{
+    const uint8_t *p, *end;
+    size_t code_len;
+    uint32_t payload_size;
+    int flags;
+
+    if (meta)
+        memset(meta, 0, sizeof(*meta));
+    if (!bc_buf || bc_buf_len < RE_HEADER_LEN)
+        return -1;
+    code_len = get_u32(bc_buf + RE_HEADER_BYTECODE_LEN);
+    if (code_len > bc_buf_len - RE_HEADER_LEN)
+        return -1;
+    p = bc_buf + RE_HEADER_LEN + code_len;
+    end = bc_buf + bc_buf_len;
+    flags = get_u16(bc_buf + RE_HEADER_FLAGS);
+    if (!(flags & LRE_FLAG_HAS_META)) {
+        if (ptrailer)
+            *ptrailer = p;
+        return 0;
+    }
+    if ((size_t)(end - p) < LRE_META_HEADER_LEN ||
+        p[LRE_META_VERSION_OFFSET] != LRE_META_VERSION ||
+        p[LRE_META_KIND_OFFSET] <= LRE_META_NONE ||
+        p[LRE_META_KIND_OFFSET] > LRE_META_QUICK_CHECK ||
+        p[LRE_META_ENCODING_OFFSET] > 1 ||
+        (p[LRE_META_FLAGS_OFFSET] & ~LRE_META_FLAG_SOURCE)) {
+        return -1;
+    }
+    payload_size = get_u32(p + LRE_META_PAYLOAD_SIZE_OFFSET);
+    if (payload_size > (size_t)(end - p - LRE_META_HEADER_LEN))
+        return -1;
+    if (meta) {
+        meta->kind = p[LRE_META_KIND_OFFSET];
+        meta->encoding = p[LRE_META_ENCODING_OFFSET];
+        meta->flags = p[LRE_META_FLAGS_OFFSET];
+        meta->payload_size = payload_size;
+        meta->length = get_u32(p + LRE_META_LENGTH_OFFSET);
+        meta->entry_offset = get_u32(p + LRE_META_ENTRY_OFFSET);
+        meta->payload = p + LRE_META_HEADER_LEN;
+    }
+    if (ptrailer)
+        *ptrailer = p + LRE_META_HEADER_LEN + payload_size;
+    return 1;
+}
+
+int lre_get_metadata(const uint8_t *bc_buf, size_t bc_buf_len,
+                     LREMetadata *meta)
+{
+    if (!meta)
+        return -1;
+    return lre_parse_metadata(bc_buf, bc_buf_len, meta, NULL);
 }
 
 /* insert 'len' bytes at position 'pos'. Return < 0 if error. */
@@ -2524,8 +2997,8 @@ uint8_t *lre_compile(int *plen, char *error_msg, int error_msg_size,
                      void *opaque)
 {
     REParseState s_s, *s = &s_s;
-    int register_count;
-    BOOL is_sticky;
+    int register_count, metadata_result;
+    BOOL is_sticky, payload_matches_source;
 
     memset(s, 0, sizeof(*s));
     s->opaque = opaque;
@@ -2542,6 +3015,7 @@ uint8_t *lre_compile(int *plen, char *error_msg, int error_msg_size,
     s->capture_count = 1;
     s->total_capture_count = -1;
     s->has_named_captures = -1;
+    payload_matches_source = lre_is_raw_atom(buf, buf_len, re_flags);
 
     dbuf_init2(&s->byte_code, opaque, lre_bytecode_realloc);
     dbuf_init2(&s->group_names, opaque, lre_realloc);
@@ -2595,6 +3069,16 @@ uint8_t *lre_compile(int *plen, char *error_msg, int error_msg_size,
     s->byte_code.buf[RE_HEADER_REGISTER_COUNT] = register_count;
     put_u32(s->byte_code.buf + RE_HEADER_BYTECODE_LEN,
             s->byte_code.size - RE_HEADER_LEN);
+    metadata_result = re_append_literal_metadata(s, re_flags,
+                                                 payload_matches_source);
+    if (metadata_result == 0)
+        metadata_result = re_append_prefix_metadata(s, re_flags);
+    if (metadata_result == 0)
+        metadata_result = re_append_quick_check_metadata(s, re_flags);
+    if (metadata_result < 0) {
+        re_parse_out_of_memory(s);
+        goto error;
+    }
 
     /* add the named groups if needed */
     if (s->group_names.size > (s->capture_count - 1) * LRE_GROUP_NAME_TRAILER_LEN) {
@@ -3323,9 +3807,10 @@ static intptr_t lre_exec_backtrack(REExecContext *s, uint8_t **capture,
 /* Return 1 if match, 0 if not match or < 0 if error (see LRE_RET_x). cindex is the
    starting position of the match and must be such as 0 <= cindex <=
    clen. */
-int lre_exec(uint8_t **capture,
-             const uint8_t *bc_buf, const uint8_t *cbuf, int cindex, int clen,
-             int cbuf_type, void *opaque)
+static int lre_exec_internal(uint8_t **capture, const uint8_t *bc_buf,
+                             uint32_t bytecode_offset,
+                             const uint8_t *cbuf, int cindex, int clen,
+                             int cbuf_type, void *opaque)
 {
     REExecContext s_s, *s = &s_s;
     int re_flags, i, ret;
@@ -3356,11 +3841,506 @@ int lre_exec(uint8_t **capture,
         }
     }
 
-    ret = lre_exec_backtrack(s, capture, bc_buf + RE_HEADER_LEN, cptr);
+    ret = lre_exec_backtrack(s, capture,
+                             bc_buf + RE_HEADER_LEN + bytecode_offset, cptr);
 
     if (s->stack_buf != s->static_stack_buf)
         lre_realloc(s->opaque, s->stack_buf, 0);
     return ret;
+}
+
+int lre_exec(uint8_t **capture,
+             const uint8_t *bc_buf, const uint8_t *cbuf, int cindex, int clen,
+             int cbuf_type, void *opaque)
+{
+    return lre_exec_internal(capture, bc_buf, 0, cbuf, cindex, clen,
+                             cbuf_type, opaque);
+}
+
+int lre_exec_at(uint8_t **capture,
+                const uint8_t *bc_buf, uint32_t bytecode_offset,
+                const uint8_t *cbuf, int cindex, int clen,
+                int cbuf_type, void *opaque)
+{
+    uint32_t bytecode_len = get_u32(bc_buf + RE_HEADER_BYTECODE_LEN);
+
+    if (bytecode_len < 2 || bytecode_offset > bytecode_len - 2 ||
+        bc_buf[RE_HEADER_LEN + bytecode_offset] != REOP_save_start ||
+        bc_buf[RE_HEADER_LEN + bytecode_offset + 1] != 0)
+        return 0;
+    return lre_exec_internal(capture, bc_buf, bytecode_offset, cbuf, cindex,
+                             clen, cbuf_type, opaque);
+}
+
+static int lre_validation_error(char *error_msg, int error_msg_size,
+                                const char *fmt, ...)
+{
+    va_list ap;
+
+    if (error_msg_size > 0) {
+        va_start(ap, fmt);
+        vsnprintf(error_msg, error_msg_size, fmt, ap);
+        va_end(ap);
+    }
+    return -1;
+}
+
+static int lre_get_jump_target(size_t *ptarget, size_t pos, size_t insn_len,
+                               uint32_t value, size_t bytecode_len)
+{
+    int64_t target;
+
+    target = (int64_t)pos + insn_len + (int32_t)value;
+    if (target < 0 || (uint64_t)target >= bytecode_len)
+        return -1;
+    *ptarget = target;
+    return 0;
+}
+
+/* Validate bytecode that may have originated outside the current process. */
+int lre_validate_bytecode(const uint8_t *bc_buf, size_t bc_buf_len,
+                          char *error_msg, int error_msg_size, void *opaque)
+{
+    static const int allowed_flags =
+        LRE_FLAG_GLOBAL | LRE_FLAG_IGNORECASE | LRE_FLAG_MULTILINE |
+        LRE_FLAG_DOTALL | LRE_FLAG_UNICODE | LRE_FLAG_STICKY |
+        LRE_FLAG_INDICES | LRE_FLAG_NAMED_GROUPS |
+        LRE_FLAG_UNICODE_SETS | LRE_FLAG_ATOM | LRE_FLAG_HAS_META;
+    const uint8_t *code, *trailer, *p, *end;
+    uint8_t *insn_map, *lookahead_end;
+    size_t code_len, pos, insn_len, target, prev_pos, char_pos, entry_pos;
+    uint32_t value, low, high, previous_high, literal_length, c;
+    uint16_t quick_offsets[LRE_QUICK_CHECK_MAX];
+    uint16_t quick_values[LRE_QUICK_CHECK_MAX];
+    uint16_t quick_masks[LRE_QUICK_CHECK_MAX];
+    int flags, capture_count, register_count;
+    int opcode, i, n, register_depth, register_max, literal_encoding;
+    int last_opcode, expected_terminal, metadata_status, quick_count;
+    LREMetadata metadata;
+
+    if (error_msg_size > 0)
+        error_msg[0] = '\0';
+    if (!bc_buf || bc_buf_len < RE_HEADER_LEN)
+        return lre_validation_error(error_msg, error_msg_size,
+                                    "regexp bytecode header is truncated");
+
+    flags = get_u16(bc_buf + RE_HEADER_FLAGS);
+    capture_count = bc_buf[RE_HEADER_CAPTURE_COUNT];
+    register_count = bc_buf[RE_HEADER_REGISTER_COUNT];
+    code_len = get_u32(bc_buf + RE_HEADER_BYTECODE_LEN);
+    if (flags & ~allowed_flags)
+        return lre_validation_error(error_msg, error_msg_size,
+                                    "regexp bytecode has unknown flags");
+    if (capture_count == 0)
+        return lre_validation_error(error_msg, error_msg_size,
+                                    "regexp bytecode has no capture zero");
+    if ((flags & LRE_FLAG_ATOM) && capture_count != 1)
+        return lre_validation_error(error_msg, error_msg_size,
+                                    "regexp atom has captures");
+    if ((flags & LRE_FLAG_ATOM) && !(flags & LRE_FLAG_HAS_META))
+        return lre_validation_error(error_msg, error_msg_size,
+                                    "regexp atom has no metadata");
+    if (code_len == 0 || code_len > bc_buf_len - RE_HEADER_LEN)
+        return lre_validation_error(error_msg, error_msg_size,
+                                    "regexp bytecode length is invalid");
+    if (code_len > SIZE_MAX / 2)
+        return lre_validation_error(error_msg, error_msg_size,
+                                    "regexp bytecode is too large");
+
+    code = bc_buf + RE_HEADER_LEN;
+    metadata_status = lre_parse_metadata(bc_buf, bc_buf_len, &metadata,
+                                         &trailer);
+    if (metadata_status < 0)
+        return lre_validation_error(error_msg, error_msg_size,
+                                    "regexp metadata is malformed");
+    if (!!(flags & LRE_FLAG_HAS_META) != (metadata_status > 0))
+        return lre_validation_error(error_msg, error_msg_size,
+                                    "regexp metadata flag is inconsistent");
+    if (metadata_status > 0) {
+        if (metadata.kind == LRE_META_LITERAL ||
+            metadata.kind == LRE_META_PREFIX) {
+            if (metadata.length == 0 ||
+                metadata.length > UINT32_MAX >> metadata.encoding ||
+                metadata.payload_size !=
+                    (metadata.length << metadata.encoding)) {
+                return lre_validation_error(error_msg, error_msg_size,
+                                            "regexp literal metadata is invalid");
+            }
+            if (metadata.kind == LRE_META_PREFIX && metadata.flags != 0)
+                return lre_validation_error(error_msg, error_msg_size,
+                                            "regexp prefix flags are invalid");
+        } else {
+            if (metadata.flags != 0 || metadata.encoding != 0 ||
+                metadata.length < 3 ||
+                metadata.length > LRE_QUICK_CHECK_MAX ||
+                metadata.payload_size !=
+                    metadata.length * LRE_QUICK_CHECK_RECORD_SIZE) {
+                return lre_validation_error(error_msg, error_msg_size,
+                                            "regexp quick-check metadata is invalid");
+            }
+            for(i = 0; i < (int)metadata.length; i++) {
+                const uint8_t *record = metadata.payload +
+                    i * LRE_QUICK_CHECK_RECORD_SIZE;
+                uint32_t offset = get_u16(record + LRE_QUICK_CHECK_OFFSET);
+                uint32_t check_value = get_u16(record + LRE_QUICK_CHECK_VALUE);
+                uint32_t mask = get_u16(record + LRE_QUICK_CHECK_MASK);
+
+                if (offset >= LRE_QUICK_CHECK_MAX || mask == 0 ||
+                    (check_value & ~mask) != 0 ||
+                    (i != 0 && offset <= get_u16(
+                         record - LRE_QUICK_CHECK_RECORD_SIZE +
+                         LRE_QUICK_CHECK_OFFSET))) {
+                    return lre_validation_error(error_msg, error_msg_size,
+                                                "regexp quick-check record is invalid");
+                }
+            }
+        }
+    }
+    if ((flags & LRE_FLAG_ATOM) && metadata.kind != LRE_META_LITERAL)
+        return lre_validation_error(error_msg, error_msg_size,
+                                    "regexp atom metadata is not literal");
+    if (metadata_status > 0 &&
+        (metadata.kind == LRE_META_LITERAL ||
+         metadata.kind == LRE_META_PREFIX)) {
+        BOOL metadata_matches;
+
+        if (metadata.kind == LRE_META_LITERAL) {
+            entry_pos = 11;
+            metadata_matches = re_has_literal_body(
+                bc_buf, RE_HEADER_LEN + code_len, flags, capture_count,
+                &char_pos, &literal_length, &literal_encoding);
+        } else {
+            metadata_matches = re_get_linear_prefix(
+                bc_buf, RE_HEADER_LEN + code_len, flags, &entry_pos,
+                &char_pos, &literal_length, &literal_encoding);
+        }
+        if (!metadata_matches || literal_length != metadata.length ||
+            literal_encoding != metadata.encoding ||
+            entry_pos != metadata.entry_offset) {
+            return lre_validation_error(error_msg, error_msg_size,
+                                        "regexp optimization metadata is inconsistent");
+        }
+        pos = char_pos;
+        for(i = 0; i < (int)literal_length; i++) {
+            if (code[pos] == REOP_char) {
+                c = get_u16(code + pos + 1);
+                pos += 3;
+            } else {
+                c = get_u32(code + pos + 1);
+                pos += 5;
+            }
+            if (c != (metadata.encoding ?
+                      get_u16(metadata.payload + i * 2) :
+                      metadata.payload[i])) {
+                return lre_validation_error(error_msg, error_msg_size,
+                                            "regexp metadata payload is inconsistent");
+            }
+        }
+    } else if (metadata_status > 0 &&
+               metadata.kind == LRE_META_QUICK_CHECK) {
+        if (!re_get_quick_checks(bc_buf, RE_HEADER_LEN + code_len, flags,
+                                 quick_offsets, quick_values, quick_masks,
+                                 &quick_count, &entry_pos) ||
+            quick_count != (int)metadata.length ||
+            entry_pos != metadata.entry_offset) {
+            return lre_validation_error(error_msg, error_msg_size,
+                                        "regexp quick-check metadata is inconsistent");
+        }
+        for(i = 0; i < quick_count; i++) {
+            const uint8_t *record = metadata.payload +
+                i * LRE_QUICK_CHECK_RECORD_SIZE;
+            if (get_u16(record + LRE_QUICK_CHECK_OFFSET) != quick_offsets[i] ||
+                get_u16(record + LRE_QUICK_CHECK_VALUE) != quick_values[i] ||
+                get_u16(record + LRE_QUICK_CHECK_MASK) != quick_masks[i]) {
+                return lre_validation_error(error_msg, error_msg_size,
+                                            "regexp quick-check payload is inconsistent");
+            }
+        }
+    }
+    insn_map = lre_realloc(opaque, NULL, code_len * 2);
+    if (!insn_map)
+        return lre_validation_error(error_msg, error_msg_size,
+                                    "out of memory validating regexp bytecode");
+    memset(insn_map, 0, code_len * 2);
+    lookahead_end = insn_map + code_len;
+
+    pos = 0;
+    register_depth = 0;
+    register_max = 0;
+    last_opcode = REOP_invalid;
+    while (pos < code_len) {
+        opcode = code[pos];
+        if (opcode <= REOP_invalid || opcode >= REOP_COUNT) {
+            lre_validation_error(error_msg, error_msg_size,
+                                 "invalid regexp opcode %d at %zu", opcode, pos);
+            goto fail;
+        }
+        insn_map[pos] = opcode + 1;
+        insn_len = reopcode_info[opcode].size;
+        if (insn_len > code_len - pos) {
+            lre_validation_error(error_msg, error_msg_size,
+                                 "truncated regexp opcode at %zu", pos);
+            goto fail;
+        }
+
+        switch(opcode) {
+        case REOP_range:
+        case REOP_range_i:
+            n = get_u16(code + pos + 1);
+            if (n == 0 || (size_t)n > (code_len - pos - insn_len) / 4) {
+                lre_validation_error(error_msg, error_msg_size,
+                                     "invalid regexp range at %zu", pos);
+                goto fail;
+            }
+            insn_len += (size_t)n * 4;
+            previous_high = 0;
+            for(i = 0; i < n; i++) {
+                low = get_u16(code + pos + 3 + i * 4);
+                high = get_u16(code + pos + 5 + i * 4);
+                if (low > high || (i != 0 && low <= previous_high)) {
+                    lre_validation_error(error_msg, error_msg_size,
+                                         "unordered regexp range at %zu", pos);
+                    goto fail;
+                }
+                previous_high = high;
+            }
+            break;
+        case REOP_range32:
+        case REOP_range32_i:
+            n = get_u16(code + pos + 1);
+            if (n == 0 || (size_t)n > (code_len - pos - insn_len) / 8) {
+                lre_validation_error(error_msg, error_msg_size,
+                                     "invalid regexp range32 at %zu", pos);
+                goto fail;
+            }
+            insn_len += (size_t)n * 8;
+            previous_high = 0;
+            for(i = 0; i < n; i++) {
+                low = get_u32(code + pos + 3 + i * 8);
+                high = get_u32(code + pos + 7 + i * 8);
+                if (low > high || (i != 0 && low <= previous_high)) {
+                    lre_validation_error(error_msg, error_msg_size,
+                                         "unordered regexp range32 at %zu", pos);
+                    goto fail;
+                }
+                previous_high = high;
+            }
+            break;
+        case REOP_back_reference:
+        case REOP_back_reference_i:
+        case REOP_backward_back_reference:
+        case REOP_backward_back_reference_i:
+            n = code[pos + 1];
+            if (n == 0 || (size_t)n > code_len - pos - insn_len) {
+                lre_validation_error(error_msg, error_msg_size,
+                                     "invalid regexp back reference at %zu", pos);
+                goto fail;
+            }
+            insn_len += n;
+            for(i = 0; i < n; i++) {
+                if (code[pos + 2 + i] >= capture_count) {
+                    lre_validation_error(error_msg, error_msg_size,
+                                         "invalid capture reference at %zu", pos);
+                    goto fail;
+                }
+            }
+            break;
+        case REOP_save_start:
+        case REOP_save_end:
+            if (code[pos + 1] >= capture_count) {
+                lre_validation_error(error_msg, error_msg_size,
+                                     "invalid capture index at %zu", pos);
+                goto fail;
+            }
+            break;
+        case REOP_save_reset:
+            if (code[pos + 1] > code[pos + 2] ||
+                code[pos + 2] >= capture_count) {
+                lre_validation_error(error_msg, error_msg_size,
+                                     "invalid capture reset at %zu", pos);
+                goto fail;
+            }
+            break;
+        case REOP_set_i32:
+        case REOP_set_char_pos:
+            if (code[pos + 1] != register_depth ||
+                register_depth >= REGISTER_COUNT_MAX) {
+                lre_validation_error(error_msg, error_msg_size,
+                                     "invalid register push at %zu", pos);
+                goto fail;
+            }
+            register_depth++;
+            register_max = max_int(register_max, register_depth);
+            break;
+        case REOP_check_advance:
+        case REOP_loop:
+        case REOP_loop_split_goto_first:
+        case REOP_loop_split_next_first:
+            if (register_depth < 1 || code[pos + 1] != register_depth - 1) {
+                lre_validation_error(error_msg, error_msg_size,
+                                     "invalid register pop at %zu", pos);
+                goto fail;
+            }
+            register_depth--;
+            break;
+        case REOP_loop_check_adv_split_goto_first:
+        case REOP_loop_check_adv_split_next_first:
+            if (register_depth < 2 || code[pos + 1] != register_depth - 2) {
+                lre_validation_error(error_msg, error_msg_size,
+                                     "invalid register pair at %zu", pos);
+                goto fail;
+            }
+            register_depth -= 2;
+            break;
+        default:
+            break;
+        }
+        last_opcode = opcode;
+        pos += insn_len;
+    }
+
+    if (pos != code_len || last_opcode != REOP_match) {
+        lre_validation_error(error_msg, error_msg_size,
+                             "regexp bytecode has no final match");
+        goto fail;
+    }
+    if (register_depth != 0 || register_max != register_count) {
+        lre_validation_error(error_msg, error_msg_size,
+                             "regexp register count is inconsistent");
+        goto fail;
+    }
+
+    pos = 0;
+    while (pos < code_len) {
+        opcode = code[pos];
+        insn_len = reopcode_info[opcode].size;
+        switch(opcode) {
+        case REOP_range:
+        case REOP_range_i:
+            insn_len += (size_t)get_u16(code + pos + 1) * 4;
+            break;
+        case REOP_range32:
+        case REOP_range32_i:
+            insn_len += (size_t)get_u16(code + pos + 1) * 8;
+            break;
+        case REOP_back_reference:
+        case REOP_back_reference_i:
+        case REOP_backward_back_reference:
+        case REOP_backward_back_reference_i:
+            insn_len += code[pos + 1];
+            break;
+        default:
+            break;
+        }
+
+        switch(opcode) {
+        case REOP_goto:
+        case REOP_split_goto_first:
+        case REOP_split_next_first:
+        case REOP_lookahead:
+        case REOP_negative_lookahead:
+            value = get_u32(code + pos + 1);
+            if (lre_get_jump_target(&target, pos, insn_len, value, code_len) ||
+                insn_map[target] == 0) {
+                lre_validation_error(error_msg, error_msg_size,
+                                     "invalid regexp jump at %zu", pos);
+                goto fail;
+            }
+            if (opcode == REOP_lookahead || opcode == REOP_negative_lookahead) {
+                if (target <= pos + insn_len) {
+                    lre_validation_error(error_msg, error_msg_size,
+                                         "invalid regexp lookahead at %zu", pos);
+                    goto fail;
+                }
+                prev_pos = target - 1;
+                while (prev_pos > pos && insn_map[prev_pos] == 0)
+                    prev_pos--;
+                expected_terminal = (opcode == REOP_lookahead) ?
+                    REOP_lookahead_match : REOP_negative_lookahead_match;
+                if (insn_map[prev_pos] != expected_terminal + 1) {
+                    lre_validation_error(error_msg, error_msg_size,
+                                         "missing regexp lookahead end at %zu", pos);
+                    goto fail;
+                }
+                lookahead_end[prev_pos] = expected_terminal + 1;
+            }
+            break;
+        case REOP_loop:
+            value = get_u32(code + pos + 2);
+            if (lre_get_jump_target(&target, pos, insn_len, value, code_len) ||
+                insn_map[target] == 0) {
+                lre_validation_error(error_msg, error_msg_size,
+                                     "invalid regexp loop at %zu", pos);
+                goto fail;
+            }
+            break;
+        case REOP_loop_split_goto_first:
+        case REOP_loop_split_next_first:
+        case REOP_loop_check_adv_split_goto_first:
+        case REOP_loop_check_adv_split_next_first:
+            value = get_u32(code + pos + 6);
+            if (lre_get_jump_target(&target, pos, insn_len, value, code_len) ||
+                insn_map[target] == 0) {
+                lre_validation_error(error_msg, error_msg_size,
+                                     "invalid regexp split loop at %zu", pos);
+                goto fail;
+            }
+            break;
+        case REOP_lookahead_match:
+        case REOP_negative_lookahead_match:
+            if (lookahead_end[pos] != opcode + 1) {
+                lre_validation_error(error_msg, error_msg_size,
+                                     "orphan regexp lookahead end at %zu", pos);
+                goto fail;
+            }
+            break;
+        default:
+            break;
+        }
+        pos += insn_len;
+    }
+
+    if (flags & LRE_FLAG_NAMED_GROUPS) {
+        if (capture_count <= 1) {
+            lre_validation_error(error_msg, error_msg_size,
+                                 "regexp named groups have no captures");
+            goto fail;
+        }
+        p = trailer;
+        end = bc_buf + bc_buf_len;
+        for(i = 1; i < capture_count; i++) {
+            const uint8_t *nul;
+
+            if (p >= end) {
+                lre_validation_error(error_msg, error_msg_size,
+                                     "regexp group names are truncated");
+                goto fail;
+            }
+            nul = memchr(p, '\0', end - p);
+            if (!nul || nul + 1 >= end) {
+                lre_validation_error(error_msg, error_msg_size,
+                                     "regexp group name is unterminated");
+                goto fail;
+            }
+            p = nul + LRE_GROUP_NAME_TRAILER_LEN;
+        }
+        if (p != end) {
+            lre_validation_error(error_msg, error_msg_size,
+                                 "regexp group name trailer has extra data");
+            goto fail;
+        }
+    } else if (trailer != bc_buf + bc_buf_len) {
+        lre_validation_error(error_msg, error_msg_size,
+                             "regexp bytecode has unexpected trailing data");
+        goto fail;
+    }
+
+    lre_realloc(opaque, insn_map, 0);
+    return 0;
+
+ fail:
+    lre_realloc(opaque, insn_map, 0);
+    return -1;
 }
 
 int lre_get_alloc_count(const uint8_t *bc_buf)
@@ -3381,18 +4361,28 @@ int lre_get_flags(const uint8_t *bc_buf)
 
 /* Return NULL if no group names. Otherwise, return a pointer to
    'capture_count - 1' zero terminated UTF-8 strings. */
-const char *lre_get_groupnames(const uint8_t *bc_buf)
+const char *lre_get_groupnames(const uint8_t *bc_buf, size_t bc_buf_len)
 {
-    uint32_t re_bytecode_len;
+    const uint8_t *trailer;
+
+    if (!bc_buf || bc_buf_len < RE_HEADER_LEN)
+        return NULL;
     if ((lre_get_flags(bc_buf) & LRE_FLAG_NAMED_GROUPS) == 0)
         return NULL;
-    re_bytecode_len = get_u32(bc_buf + RE_HEADER_BYTECODE_LEN);
-    return (const char *)(bc_buf + RE_HEADER_LEN + re_bytecode_len);
+    if (lre_parse_metadata(bc_buf, bc_buf_len, NULL, &trailer) < 0 ||
+        trailer >= bc_buf + bc_buf_len)
+        return NULL;
+    return (const char *)trailer;
 }
 
 #ifdef TEST
 
 BOOL lre_check_stack_overflow(void *opaque, size_t alloca_size)
+{
+    return FALSE;
+}
+
+BOOL lre_check_timeout(void *opaque)
 {
     return FALSE;
 }
@@ -3407,7 +4397,7 @@ int main(int argc, char **argv)
     int len, flags, ret, i;
     uint8_t *bc;
     char error_msg[64];
-    uint8_t *capture;
+    uint8_t **capture;
     const char *input;
     int input_len, capture_count;
 

--- a/libregexp.h
+++ b/libregexp.h
@@ -36,6 +36,41 @@
 #define LRE_FLAG_INDICES    (1 << 6) /* Unused by libregexp, just recorded. */
 #define LRE_FLAG_NAMED_GROUPS (1 << 7) /* named groups are present in the regexp */
 #define LRE_FLAG_UNICODE_SETS (1 << 8)
+#define LRE_FLAG_ATOM       (1 << 9) /* internal: raw literal pattern */
+#define LRE_FLAG_HAS_META   (1 << 10) /* internal optimization metadata */
+
+#define LRE_META_VERSION 1
+#define LRE_META_NONE 0
+#define LRE_META_LITERAL 1
+#define LRE_META_PREFIX 2
+#define LRE_META_QUICK_CHECK 3
+
+#define LRE_META_FLAG_SOURCE 1 /* literal payload equals the source pattern */
+
+#define LRE_META_VERSION_OFFSET 0
+#define LRE_META_KIND_OFFSET 1
+#define LRE_META_ENCODING_OFFSET 2
+#define LRE_META_FLAGS_OFFSET 3
+#define LRE_META_PAYLOAD_SIZE_OFFSET 4
+#define LRE_META_LENGTH_OFFSET 8
+#define LRE_META_ENTRY_OFFSET 12
+#define LRE_META_HEADER_LEN 16
+
+#define LRE_QUICK_CHECK_OFFSET 0
+#define LRE_QUICK_CHECK_VALUE 2
+#define LRE_QUICK_CHECK_MASK 4
+#define LRE_QUICK_CHECK_RECORD_SIZE 6
+#define LRE_QUICK_CHECK_MAX 4
+
+typedef struct LREMetadata {
+    const uint8_t *payload;
+    uint32_t payload_size;
+    uint32_t length;
+    uint32_t entry_offset;
+    uint8_t kind;
+    uint8_t encoding;
+    uint8_t flags;
+} LREMetadata;
 
 #define LRE_RET_MEMORY_ERROR (-1)
 #define LRE_RET_TIMEOUT      (-2)
@@ -46,13 +81,22 @@
 uint8_t *lre_compile(int *plen, char *error_msg, int error_msg_size,
                      const char *buf, size_t buf_len, int re_flags,
                      void *opaque);
+int lre_is_raw_atom(const char *buf, size_t len, int re_flags);
+int lre_validate_bytecode(const uint8_t *bc_buf, size_t bc_buf_len,
+                          char *error_msg, int error_msg_size, void *opaque);
 int lre_get_alloc_count(const uint8_t *bc_buf);
 int lre_get_capture_count(const uint8_t *bc_buf);
 int lre_get_flags(const uint8_t *bc_buf);
-const char *lre_get_groupnames(const uint8_t *bc_buf);
+int lre_get_metadata(const uint8_t *bc_buf, size_t bc_buf_len,
+                     LREMetadata *meta);
+const char *lre_get_groupnames(const uint8_t *bc_buf, size_t bc_buf_len);
 int lre_exec(uint8_t **capture,
              const uint8_t *bc_buf, const uint8_t *cbuf, int cindex, int clen,
              int cbuf_type, void *opaque);
+int lre_exec_at(uint8_t **capture,
+                const uint8_t *bc_buf, uint32_t bytecode_offset,
+                const uint8_t *cbuf, int cindex, int clen,
+                int cbuf_type, void *opaque);
 
 int lre_parse_escape(const uint8_t **pp, int allow_utf16);
 

--- a/libregexp.h
+++ b/libregexp.h
@@ -39,13 +39,21 @@
 #define LRE_FLAG_ATOM       (1 << 9) /* internal: raw literal pattern */
 #define LRE_FLAG_HAS_META   (1 << 10) /* internal optimization metadata */
 
-#define LRE_META_VERSION 1
+/* RegExp optimization metadata is serialized little-endian after the opcode
+   stream. Source literals borrow their payload from JSRegExp.pattern; all
+   other payloads are bounded so untrusted bytecode cannot request an
+   unbounded fast-path allocation or comparison. */
+#define LRE_META_VERSION 3
 #define LRE_META_NONE 0
 #define LRE_META_LITERAL 1
 #define LRE_META_PREFIX 2
 #define LRE_META_QUICK_CHECK 3
 
-#define LRE_META_FLAG_SOURCE 1 /* literal payload equals the source pattern */
+#define LRE_META_FLAG_SOURCE 1 /* literal uses the source pattern; no payload */
+
+#define LRE_LITERAL_MAX_LENGTH 4096
+#define LRE_PREFIX_MIN_LENGTH 3
+#define LRE_PREFIX_MAX_LENGTH 32
 
 #define LRE_META_VERSION_OFFSET 0
 #define LRE_META_KIND_OFFSET 1
@@ -54,7 +62,13 @@
 #define LRE_META_PAYLOAD_SIZE_OFFSET 4
 #define LRE_META_LENGTH_OFFSET 8
 #define LRE_META_ENTRY_OFFSET 12
-#define LRE_META_HEADER_LEN 16
+#define LRE_META_EXEC_FLAGS_OFFSET 16
+#define LRE_META_LEADING_COUNT_OFFSET 20
+#define LRE_META_HEADER_LEN 24
+
+#define LRE_META_EXEC_SCAN (1 << 0)
+#define LRE_META_EXEC_LEADING (1 << 1)
+#define LRE_META_LEADING_MAX 4
 
 #define LRE_QUICK_CHECK_OFFSET 0
 #define LRE_QUICK_CHECK_VALUE 2
@@ -64,9 +78,13 @@
 
 typedef struct LREMetadata {
     const uint8_t *payload;
+    const uint8_t *leading_chars;
     uint32_t payload_size;
+    uint32_t primary_payload_size;
     uint32_t length;
     uint32_t entry_offset;
+    uint32_t exec_flags;
+    uint32_t leading_count;
     uint8_t kind;
     uint8_t encoding;
     uint8_t flags;

--- a/qjs.c
+++ b/qjs.c
@@ -42,6 +42,7 @@
 
 #include "cutils.h"
 #include "quickjs-libc.h"
+#include "quickjs-bytecode.h"
 
 extern const uint8_t qjsc_repl[];
 extern const uint32_t qjsc_repl_size;
@@ -100,6 +101,37 @@ static int eval_file(JSContext *ctx, const char *filename, int module, int stric
     }
     ret = eval_buf(ctx, buf, buf_len, filename, eval_flags);
     js_free(ctx, buf);
+    return ret;
+}
+
+static int eval_bytecode_file(JSContext *ctx, const char *filename)
+{
+    JSValue obj, val;
+    int ret = -1;
+
+    obj = qjs_bytecode_read_file(ctx, filename);
+    if (JS_IsException(obj))
+        goto exception;
+
+    if (JS_VALUE_GET_TAG(obj) == JS_TAG_MODULE) {
+        if (JS_ResolveModule(ctx, obj) < 0) {
+            JS_FreeValue(ctx, obj);
+            goto exception;
+        }
+        js_module_set_import_meta(ctx, obj, FALSE, TRUE);
+        val = JS_EvalFunction(ctx, obj);
+        val = js_std_await(ctx, val);
+    } else {
+        val = JS_EvalFunction(ctx, obj);
+    }
+    if (JS_IsException(val))
+        goto exception;
+    JS_FreeValue(ctx, val);
+    ret = 0;
+    return ret;
+
+exception:
+    js_std_dump_error(ctx);
     return ret;
 }
 
@@ -297,6 +329,7 @@ void help(void)
            "-i  --interactive  go to interactive mode\n"
            "-m  --module       load as ES6 module (default=autodetect)\n"
            "    --script       load as ES6 script (default=autodetect)\n"
+           "    --bytecode file  load a checked bytecode file\n"
            "    --strict       force strict mode\n"
            "-I  --include file include an additional file\n"
            "    --std          make 'std' and 'os' available to the loaded script\n"
@@ -324,6 +357,8 @@ int main(int argc, char **argv)
     int empty_run = 0;
     int module = -1;
     int strict = 0;
+    char *bytecode_file = NULL;
+    int bytecode_arg_index = -1;
     int load_std = 0;
     int dump_unhandled_promise_rejection = 1;
     size_t memory_limit = 0;
@@ -393,6 +428,15 @@ int main(int argc, char **argv)
                 module = 0;
                 continue;
             }
+            if (!strcmp(longopt, "bytecode")) {
+                if (optind >= argc) {
+                    fprintf(stderr, "qjs: expecting bytecode filename\n");
+                    exit(1);
+                }
+                bytecode_arg_index = optind;
+                bytecode_file = argv[optind++];
+                goto done_options;
+            }
             if (!strcmp(longopt, "strict")) {
                 strict = 1;
                 continue;
@@ -449,6 +493,12 @@ int main(int argc, char **argv)
             help();
         }
     }
+ done_options:
+
+    if (bytecode_file && expr) {
+        fprintf(stderr, "qjs: --bytecode cannot be combined with -e\n");
+        exit(1);
+    }
 
     if (trace_memory) {
         js_trace_malloc_init(&trace_data);
@@ -482,7 +532,9 @@ int main(int argc, char **argv)
     }
 
     if (!empty_run) {
-        js_std_add_helpers(ctx, argc - optind, argv + optind);
+        int script_arg_index;
+        script_arg_index = bytecode_file ? bytecode_arg_index : optind;
+        js_std_add_helpers(ctx, argc - script_arg_index, argv + script_arg_index);
 
         /* make 'std' and 'os' visible to non module code */
         if (load_std) {
@@ -508,6 +560,10 @@ int main(int argc, char **argv)
                     eval_flags |= JS_EVAL_FLAG_STRICT;
             }
             if (eval_buf(ctx, expr, strlen(expr), "<cmdline>", eval_flags))
+                goto fail;
+        } else
+        if (bytecode_file) {
+            if (eval_bytecode_file(ctx, bytecode_file))
                 goto fail;
         } else
         if (optind >= argc) {

--- a/qjsc.c
+++ b/qjsc.c
@@ -35,6 +35,7 @@
 
 #include "cutils.h"
 #include "quickjs-libc.h"
+#include "quickjs-bytecode.h"
 
 typedef struct {
     char *name;
@@ -296,13 +297,15 @@ JSModuleDef *jsc_module_loader(JSContext *ctx,
                 find_unique_cname(cname, sizeof(cname));
             }
 
-            /* output the module name */
-            fprintf(outfile, "static const uint8_t %s_module_name[] = {\n",
-                    cname);
-            dump_hex(outfile, (const uint8_t *)module_name, strlen(module_name) + 1);
-            fprintf(outfile, "};\n\n");
+            if (outfile) {
+                /* output the module name */
+                fprintf(outfile, "static const uint8_t %s_module_name[] = {\n",
+                        cname);
+                dump_hex(outfile, (const uint8_t *)module_name, strlen(module_name) + 1);
+                fprintf(outfile, "};\n\n");
 
-            output_object_code(ctx, outfile, val, cname, CNAME_TYPE_JSON_MODULE);
+                output_object_code(ctx, outfile, val, cname, CNAME_TYPE_JSON_MODULE);
+            }
             JS_FreeValue(ctx, val);
         } else {
             JSValue func_val;
@@ -317,7 +320,8 @@ JSModuleDef *jsc_module_loader(JSContext *ctx,
             if (namelist_find(&cname_list, cname)) {
                 find_unique_cname(cname, sizeof(cname));
             }
-            output_object_code(ctx, outfile, func_val, cname, CNAME_TYPE_MODULE);
+            if (outfile)
+                output_object_code(ctx, outfile, func_val, cname, CNAME_TYPE_MODULE);
             
             /* the module is already referenced, so we must free it */
             m = JS_VALUE_GET_PTR(func_val);
@@ -327,13 +331,10 @@ JSModuleDef *jsc_module_loader(JSContext *ctx,
     return m;
 }
 
-static void compile_file(JSContext *ctx, FILE *fo,
-                         const char *filename,
-                         const char *c_name1,
-                         int module)
+static JSValue compile_file_to_object(JSContext *ctx, const char *filename,
+                                      int module)
 {
     uint8_t *buf;
-    char c_name[1024];
     int eval_flags;
     JSValue obj;
     size_t buf_len;
@@ -358,6 +359,18 @@ static void compile_file(JSContext *ctx, FILE *fo,
         exit(1);
     }
     js_free(ctx, buf);
+    return obj;
+}
+
+static void compile_file(JSContext *ctx, FILE *fo,
+                         const char *filename,
+                         const char *c_name1,
+                         int module)
+{
+    char c_name[1024];
+    JSValue obj;
+
+    obj = compile_file_to_object(ctx, filename, module);
     if (c_name1) {
         pstrcpy(c_name, sizeof(c_name), c_name1);
     } else {
@@ -398,6 +411,7 @@ void help(void)
            "options are:\n"
            "-c          only output bytecode to a C file\n"
            "-e          output main() and bytecode to a C file (default = executable output)\n"
+           "-b  --bytecode  output checked bytecode to a file\n"
            "-o output   set the output filename\n"
            "-N cname    set the C name of the generated data\n"
            "-m          compile as Javascript module (default=autodetect)\n"
@@ -555,6 +569,7 @@ static size_t get_suffixed_size(const char *str)
 typedef enum {
     OUTPUT_C,
     OUTPUT_C_MAIN,
+    OUTPUT_BYTECODE,
     OUTPUT_EXECUTABLE,
 } OutputTypeEnum;
 
@@ -637,6 +652,10 @@ int main(int argc, char **argv)
             }
             if (opt == 'e') {
                 output_type = OUTPUT_C_MAIN;
+                continue;
+            }
+            if (opt == 'b' || !strcmp(longopt, "bytecode")) {
+                output_type = OUTPUT_BYTECODE;
                 continue;
             }
             if (opt == 'N') {
@@ -732,9 +751,21 @@ int main(int argc, char **argv)
     if (!out_filename) {
         if (output_type == OUTPUT_EXECUTABLE) {
             out_filename = "a.out";
+        } else if (output_type == OUTPUT_BYTECODE) {
+            out_filename = "out.qbc";
         } else {
             out_filename = "out.c";
         }
+    }
+
+    if (output_type == OUTPUT_BYTECODE && argc - optind != 1) {
+        fprintf(stderr, "qjsc: bytecode output expects exactly one input file\n");
+        exit(1);
+    }
+
+    if (output_type == OUTPUT_BYTECODE && byte_swap) {
+        fprintf(stderr, "qjsc: -x is not supported with --bytecode\n");
+        exit(1);
     }
 
     if (output_type == OUTPUT_EXECUTABLE) {
@@ -748,13 +779,6 @@ int main(int argc, char **argv)
         pstrcpy(cfilename, sizeof(cfilename), out_filename);
     }
 
-    fo = fopen(cfilename, "w");
-    if (!fo) {
-        perror(cfilename);
-        exit(1);
-    }
-    outfile = fo;
-
     rt = JS_NewRuntime();
     ctx = JS_NewContext(rt);
 
@@ -762,6 +786,31 @@ int main(int argc, char **argv)
 
     /* loader for ES6 modules */
     JS_SetModuleLoaderFunc2(rt, NULL, jsc_module_loader, NULL, NULL);
+
+    if (output_type == OUTPUT_BYTECODE) {
+        JSValue obj;
+        int ret;
+
+        obj = compile_file_to_object(ctx, argv[optind], module);
+        ret = qjs_bytecode_write_file(ctx, out_filename, obj, 0);
+        JS_FreeValue(ctx, obj);
+        if (ret) {
+            js_std_dump_error(ctx);
+        }
+        JS_FreeContext(ctx);
+        JS_FreeRuntime(rt);
+        namelist_free(&cname_list);
+        namelist_free(&cmodule_list);
+        namelist_free(&init_module_list);
+        return ret ? 1 : 0;
+    }
+
+    fo = fopen(cfilename, "w");
+    if (!fo) {
+        perror(cfilename);
+        exit(1);
+    }
+    outfile = fo;
 
     fprintf(fo, "/* File generated automatically by the QuickJS compiler. */\n"
             "\n"

--- a/quickjs-bytecode.c
+++ b/quickjs-bytecode.c
@@ -1,0 +1,161 @@
+/*
+ * QuickJS bytecode file wrapper
+ */
+#include <errno.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "cutils.h"
+#include "quickjs-libc.h"
+#include "quickjs-bytecode.h"
+
+#define QJS_BYTECODE_HEADER_SIZE 64
+#define QJS_BYTECODE_VERSION_OFFSET 12
+#define QJS_BYTECODE_VERSION_SIZE 32
+#define QJS_BYTECODE_PAYLOAD_SIZE_OFFSET 44
+#define QJS_BYTECODE_CHECKSUM_OFFSET 52
+#define QJS_BYTECODE_FLAGS_OFFSET 60
+
+static const uint8_t qjs_bytecode_magic[8] = {
+    'Q', 'J', 'S', 'B', 'C', 0, '\r', '\n'
+};
+
+static uint64_t qjs_bytecode_checksum(const uint8_t *buf, size_t len)
+{
+    uint64_t h = UINT64_C(1469598103934665603);
+    size_t i;
+
+    for (i = 0; i < len; i++) {
+        h ^= buf[i];
+        h *= UINT64_C(1099511628211);
+    }
+    return h;
+}
+
+static int qjs_bytecode_write_all(FILE *f, const void *buf, size_t len)
+{
+    return fwrite(buf, 1, len, f) == len ? 0 : -1;
+}
+
+int qjs_bytecode_write_file(JSContext *ctx, const char *filename,
+                            JSValueConst obj, int write_flags)
+{
+    uint8_t header[QJS_BYTECODE_HEADER_SIZE];
+    uint8_t *payload;
+    size_t payload_len;
+    FILE *f;
+    int ret = -1;
+
+    payload = JS_WriteObject(ctx, &payload_len, obj,
+                             write_flags | JS_WRITE_OBJ_BYTECODE);
+    if (!payload)
+        return -1;
+
+    memset(header, 0, sizeof(header));
+    memcpy(header, qjs_bytecode_magic, sizeof(qjs_bytecode_magic));
+    put_u32(header + 8, QJS_BYTECODE_HEADER_SIZE);
+    snprintf((char *)header + QJS_BYTECODE_VERSION_OFFSET,
+             QJS_BYTECODE_VERSION_SIZE, "%s", CONFIG_VERSION);
+    put_u64(header + QJS_BYTECODE_PAYLOAD_SIZE_OFFSET, payload_len);
+    put_u64(header + QJS_BYTECODE_CHECKSUM_OFFSET,
+            qjs_bytecode_checksum(payload, payload_len));
+    put_u32(header + QJS_BYTECODE_FLAGS_OFFSET, 0);
+
+    f = fopen(filename, "wb");
+    if (!f) {
+        JS_ThrowReferenceError(ctx, "could not open bytecode file '%s': %s",
+                               filename, strerror(errno));
+        goto done;
+    }
+    if (qjs_bytecode_write_all(f, header, sizeof(header)) ||
+        qjs_bytecode_write_all(f, payload, payload_len)) {
+        JS_ThrowReferenceError(ctx, "could not write bytecode file '%s': %s",
+                               filename, strerror(errno));
+        goto close_file;
+    }
+    ret = 0;
+
+close_file:
+    if (fclose(f) != 0 && ret == 0) {
+        JS_ThrowReferenceError(ctx, "could not close bytecode file '%s': %s",
+                               filename, strerror(errno));
+        ret = -1;
+    }
+done:
+    js_free(ctx, payload);
+    return ret;
+}
+
+JSValue qjs_bytecode_read_file(JSContext *ctx, const char *filename)
+{
+    uint8_t *buf;
+    const uint8_t *payload;
+    size_t buf_len, payload_len;
+    uint64_t payload_len64, checksum;
+    uint32_t header_size, flags;
+    char version[QJS_BYTECODE_VERSION_SIZE + 1];
+    JSValue obj = JS_EXCEPTION;
+
+    buf = js_load_file(ctx, &buf_len, filename);
+    if (!buf) {
+        JS_ThrowReferenceError(ctx, "could not load bytecode file '%s'",
+                               filename);
+        return JS_EXCEPTION;
+    }
+
+    if (buf_len < QJS_BYTECODE_HEADER_SIZE) {
+        JS_ThrowSyntaxError(ctx, "invalid bytecode file: header is too short");
+        goto done;
+    }
+    if (memcmp(buf, qjs_bytecode_magic, sizeof(qjs_bytecode_magic)) != 0) {
+        JS_ThrowSyntaxError(ctx, "invalid bytecode file: bad magic");
+        goto done;
+    }
+
+    header_size = get_u32(buf + 8);
+    if (header_size != QJS_BYTECODE_HEADER_SIZE) {
+        JS_ThrowSyntaxError(ctx, "invalid bytecode file: unsupported header size");
+        goto done;
+    }
+
+    memcpy(version, buf + QJS_BYTECODE_VERSION_OFFSET,
+           QJS_BYTECODE_VERSION_SIZE);
+    version[QJS_BYTECODE_VERSION_SIZE] = '\0';
+    if (strcmp(version, CONFIG_VERSION) != 0) {
+        JS_ThrowSyntaxError(ctx,
+                            "bytecode version mismatch: file uses '%s', runtime uses '%s'",
+                            version, CONFIG_VERSION);
+        goto done;
+    }
+
+    flags = get_u32(buf + QJS_BYTECODE_FLAGS_OFFSET);
+    if (flags != 0) {
+        JS_ThrowSyntaxError(ctx, "invalid bytecode file: unsupported flags");
+        goto done;
+    }
+
+    payload_len64 = get_u64(buf + QJS_BYTECODE_PAYLOAD_SIZE_OFFSET);
+    if (payload_len64 > SIZE_MAX) {
+        JS_ThrowSyntaxError(ctx, "invalid bytecode file: payload is too large");
+        goto done;
+    }
+    payload_len = (size_t)payload_len64;
+    if (payload_len != buf_len - QJS_BYTECODE_HEADER_SIZE) {
+        JS_ThrowSyntaxError(ctx, "invalid bytecode file: size mismatch");
+        goto done;
+    }
+
+    payload = buf + QJS_BYTECODE_HEADER_SIZE;
+    checksum = get_u64(buf + QJS_BYTECODE_CHECKSUM_OFFSET);
+    if (checksum != qjs_bytecode_checksum(payload, payload_len)) {
+        JS_ThrowSyntaxError(ctx, "bytecode checksum mismatch");
+        goto done;
+    }
+
+    obj = JS_ReadObject(ctx, payload, payload_len, JS_READ_OBJ_BYTECODE);
+
+done:
+    js_free(ctx, buf);
+    return obj;
+}

--- a/quickjs-bytecode.h
+++ b/quickjs-bytecode.h
@@ -1,0 +1,13 @@
+/*
+ * QuickJS bytecode file wrapper
+ */
+#ifndef QUICKJS_BYTECODE_H
+#define QUICKJS_BYTECODE_H
+
+#include "quickjs.h"
+
+int qjs_bytecode_write_file(JSContext *ctx, const char *filename,
+                            JSValueConst obj, int write_flags);
+JSValue qjs_bytecode_read_file(JSContext *ctx, const char *filename);
+
+#endif /* QUICKJS_BYTECODE_H */

--- a/quickjs.c
+++ b/quickjs.c
@@ -37503,7 +37503,7 @@ typedef enum BCTagEnum {
     BC_TAG_OBJECT_REFERENCE,
 } BCTagEnum;
 
-#define BC_VERSION 6
+#define BC_VERSION 8
 
 typedef struct BCWriterState {
     JSContext *ctx;
@@ -38780,7 +38780,7 @@ static int js_validate_regexp_constant(JSContext *ctx, JSFunctionBytecode *b,
         return -1;
     }
 
-    /* Older payloads may omit the optional ATOM optimization marker. */
+    /* Serialized payloads may omit the optional ATOM optimization marker. */
     if (!(serialized_flags & LRE_FLAG_ATOM)) {
         put_u16(trusted_bytecode,
                 lre_get_flags(trusted_bytecode) & ~LRE_FLAG_ATOM);
@@ -47946,6 +47946,22 @@ static JSValue js_compile_regexp(JSContext *ctx, JSValueConst pattern,
     return ret;
 }
 
+/* The caller transfers its existing pattern and bytecode references to re.
+   metadata is a borrowed view and must always be derived from bytecode. */
+static void js_regexp_set_compiled_data(JSRegExp *re, JSString *pattern,
+                                        JSString *bytecode)
+{
+    LREMetadata metadata;
+
+    re->pattern = pattern;
+    re->bytecode = bytecode;
+    re->metadata = NULL;
+    if (!bytecode->is_wide_char &&
+        lre_get_metadata(bytecode->u.str8, bytecode->len, &metadata) == 1) {
+        re->metadata = metadata.payload - LRE_META_HEADER_LEN;
+    }
+}
+
 /* fast regexp creation */
 static JSValue JS_NewRegexp(JSContext *ctx, JSValue pattern, JSValue bc)
 {
@@ -47953,7 +47969,6 @@ static JSValue JS_NewRegexp(JSContext *ctx, JSValue pattern, JSValue bc)
     JSProperty props[1];
     JSObject *p;
     JSRegExp *re;
-    LREMetadata metadata;
 
     /* sanity check */
     if (unlikely(JS_VALUE_GET_TAG(bc) != JS_TAG_STRING ||
@@ -47967,14 +47982,8 @@ static JSValue JS_NewRegexp(JSContext *ctx, JSValue pattern, JSValue bc)
         goto fail;
     p = JS_VALUE_GET_OBJ(obj);
     re = &p->u.regexp;
-    re->pattern = JS_VALUE_GET_STRING(pattern);
-    re->bytecode = JS_VALUE_GET_STRING(bc);
-    if (!re->bytecode->is_wide_char &&
-        lre_get_metadata(re->bytecode->u.str8, re->bytecode->len,
-                         &metadata) == 1)
-        re->metadata = metadata.payload - LRE_META_HEADER_LEN;
-    else
-        re->metadata = NULL;
+    js_regexp_set_compiled_data(re, JS_VALUE_GET_STRING(pattern),
+                               JS_VALUE_GET_STRING(bc));
     return obj;
  fail:
     JS_FreeValue(ctx, bc);
@@ -47989,7 +47998,6 @@ static JSValue js_regexp_set_internal(JSContext *ctx,
 {
     JSObject *p;
     JSRegExp *re;
-    LREMetadata metadata;
 
     /* sanity check */
     if (unlikely(JS_VALUE_GET_TAG(bc) != JS_TAG_STRING ||
@@ -48003,14 +48011,8 @@ static JSValue js_regexp_set_internal(JSContext *ctx,
 
     p = JS_VALUE_GET_OBJ(obj);
     re = &p->u.regexp;
-    re->pattern = JS_VALUE_GET_STRING(pattern);
-    re->bytecode = JS_VALUE_GET_STRING(bc);
-    if (!re->bytecode->is_wide_char &&
-        lre_get_metadata(re->bytecode->u.str8, re->bytecode->len,
-                         &metadata) == 1)
-        re->metadata = metadata.payload - LRE_META_HEADER_LEN;
-    else
-        re->metadata = NULL;
+    js_regexp_set_compiled_data(re, JS_VALUE_GET_STRING(pattern),
+                               JS_VALUE_GET_STRING(bc));
     /* Note: cannot fail because the field is preallocated */
     JS_DefinePropertyValue(ctx, obj, JS_ATOM_lastIndex, JS_NewInt32(ctx, 0),
                            JS_PROP_WRITABLE);
@@ -48160,8 +48162,8 @@ static JSValue js_regexp_compile(JSContext *ctx, JSValueConst this_val,
     }
     JS_FreeValue(ctx, JS_MKPTR(JS_TAG_STRING, re->pattern));
     JS_FreeValue(ctx, JS_MKPTR(JS_TAG_STRING, re->bytecode));
-    re->pattern = JS_VALUE_GET_STRING(pattern);
-    re->bytecode = JS_VALUE_GET_STRING(bc);
+    js_regexp_set_compiled_data(re, JS_VALUE_GET_STRING(pattern),
+                               JS_VALUE_GET_STRING(bc));
     if (JS_SetProperty(ctx, this_val, JS_ATOM_lastIndex,
                        JS_NewInt32(ctx, 0)) < 0)
         return JS_EXCEPTION;
@@ -48425,7 +48427,15 @@ static force_inline int js_regexp_set_lastIndex(JSContext *ctx, JSValueConst thi
     return 0;
 }
 
+#ifndef JS_REGEXP_CAPTURE_STACK_SIZE
 #define JS_REGEXP_CAPTURE_STACK_SIZE 16
+#endif
+#if JS_REGEXP_CAPTURE_STACK_SIZE < 2 || JS_REGEXP_CAPTURE_STACK_SIZE > 512
+#error "JS_REGEXP_CAPTURE_STACK_SIZE must be between 2 and 512"
+#endif
+/* The default capture array uses 64 bytes on 32-bit and 128 bytes on
+   64-bit targets. Larger expressions fall back to the runtime allocator. */
+#define JS_REGEXP_SCAN_CHUNK_SIZE 65536
 
 static force_inline const uint8_t *
 js_regexp_get_atom(int re_flags, int capture_count, const JSRegExp *re)
@@ -48508,38 +48518,127 @@ static force_inline BOOL js_regexp_atom_starts_at(JSString *str, int start,
     return TRUE;
 }
 
-static force_inline int js_regexp_match_atom(uint8_t **capture, JSString *str,
+static force_inline int js_regexp_indexof_char_range(JSString *str, int c,
+                                                     int from, int to)
+{
+    int i;
+
+    if (str->is_wide_char) {
+        if (c > 0xffff)
+            return -1;
+        for(i = from; i < to; i++) {
+            if (str->u.str16[i] == c)
+                return i;
+        }
+    } else if ((c & ~0xff) == 0) {
+        const uint8_t *p = memchr(str->u.str8 + from, c, to - from);
+
+        if (p)
+            return p - str->u.str8;
+    }
+    return -1;
+}
+
+static int js_regexp_find_source_atom(JSContext *ctx, JSString *str,
+                                      JSString *pattern, int start_index,
+                                      int *pstart)
+{
+    int c, candidate, chunk_end, limit;
+
+    if (pattern->len > str->len) {
+        *pstart = -1;
+        return 0;
+    }
+    limit = str->len - pattern->len + 1;
+    c = string_get(pattern, 0);
+    while (start_index < limit) {
+        chunk_end = start_index +
+            min_int(limit - start_index, JS_REGEXP_SCAN_CHUNK_SIZE);
+        while (start_index < chunk_end) {
+            candidate = js_regexp_indexof_char_range(str, c, start_index,
+                                                     chunk_end);
+            if (candidate < 0)
+                break;
+            if (js_regexp_source_starts_at(str, candidate, pattern)) {
+                *pstart = candidate;
+                return 0;
+            }
+            start_index = candidate + 1;
+        }
+        start_index = chunk_end;
+        if (start_index < limit && lre_check_timeout(ctx))
+            return LRE_RET_TIMEOUT;
+    }
+    *pstart = -1;
+    return 0;
+}
+
+static int js_regexp_find_decoded_atom(JSContext *ctx, JSString *str,
+                                       const uint8_t *atom, int start_index,
+                                       int *pstart)
+{
+    int c, candidate, chunk_end, len, limit;
+
+    len = get_u32(atom + LRE_META_LENGTH_OFFSET);
+    if (len > str->len) {
+        *pstart = -1;
+        return 0;
+    }
+    limit = str->len - len + 1;
+    c = js_regexp_atom_char(atom, 0);
+    while (start_index < limit) {
+        chunk_end = start_index +
+            min_int(limit - start_index, JS_REGEXP_SCAN_CHUNK_SIZE);
+        while (start_index < chunk_end) {
+            candidate = js_regexp_indexof_char_range(str, c, start_index,
+                                                     chunk_end);
+            if (candidate < 0)
+                break;
+            if (js_regexp_atom_starts_at(str, candidate, atom)) {
+                *pstart = candidate;
+                return 0;
+            }
+            start_index = candidate + 1;
+        }
+        start_index = chunk_end;
+        if (start_index < limit && lre_check_timeout(ctx))
+            return LRE_RET_TIMEOUT;
+    }
+    *pstart = -1;
+    return 0;
+}
+
+static force_inline int js_regexp_match_atom(JSContext *ctx,
+                                             uint8_t **capture, JSString *str,
                                              const uint8_t *atom,
                                              JSString *pattern,
                                              int start_index)
 {
-    int c, i, start, shift, len;
+    int ret, start, shift, len;
 
     if (atom[LRE_META_FLAGS_OFFSET] & LRE_META_FLAG_SOURCE) {
         len = pattern->len;
-        if (start_index + pattern->len <= str->len &&
+        if (len <= str->len - start_index &&
             js_regexp_source_starts_at(str, start_index, pattern)) {
             start = start_index;
+            ret = 0;
         } else {
-            start = string_indexof(str, pattern, start_index);
+            ret = js_regexp_find_source_atom(ctx, str, pattern,
+                                             start_index + 1, &start);
         }
-    } else if (js_regexp_atom_starts_at(str, start_index, atom)) {
-        len = get_u32(atom + LRE_META_LENGTH_OFFSET);
-        start = start_index;
     } else {
         len = get_u32(atom + LRE_META_LENGTH_OFFSET);
-        start = -1;
-        c = js_regexp_atom_char(atom, 0);
-        for(i = start_index; i + len <= str->len; i = start + 1) {
-            start = string_indexof_char(str, c, i);
-            if (start < 0 || start + len > str->len) {
-                start = -1;
-                break;
-            }
-            if (js_regexp_atom_starts_at(str, start, atom))
-                break;
+        if (len <= str->len - start_index &&
+            js_regexp_atom_starts_at(str, start_index, atom)) {
+            start = start_index;
+            ret = 0;
+        } else {
+            ret = js_regexp_find_decoded_atom(ctx, str, atom,
+                                              start_index + 1, &start);
         }
     }
+    if (ret < 0)
+        return ret;
     if (start < 0)
         return 0;
     shift = str->is_wide_char;
@@ -48553,28 +48652,35 @@ static int js_regexp_match_prefix(JSContext *ctx, uint8_t **capture,
                                   const uint8_t *prefix, JSString *str,
                                   int start_index)
 {
-    int c, candidate, i, ret, attempts, len, shift;
+    int c, candidate, chunk_end, ret, len, limit, shift;
 
     len = get_u32(prefix + LRE_META_LENGTH_OFFSET);
     shift = str->is_wide_char;
     c = js_regexp_atom_char(prefix, 0);
     candidate = start_index;
-    attempts = 0;
-    while (candidate + len <= str->len) {
-        candidate = string_indexof_char(str, c, candidate);
-        if (candidate < 0 || candidate + len > str->len)
-            return 0;
-        if (js_regexp_atom_starts_at(str, candidate, prefix)) {
-            ret = lre_exec_at(capture, re_bytecode,
-                              get_u32(prefix + LRE_META_ENTRY_OFFSET),
-                              str->u.str8, candidate, str->len, shift, ctx);
-            if (ret != 0)
-                return ret;
-            if ((++attempts & 1023) == 0 && lre_check_timeout(ctx))
-                return LRE_RET_TIMEOUT;
+    if (len > str->len)
+        return 0;
+    limit = str->len - len + 1;
+    while (candidate < limit) {
+        chunk_end = candidate +
+            min_int(limit - candidate, JS_REGEXP_SCAN_CHUNK_SIZE);
+        while (candidate < chunk_end) {
+            candidate = js_regexp_indexof_char_range(str, c, candidate,
+                                                     chunk_end);
+            if (candidate < 0)
+                break;
+            if (js_regexp_atom_starts_at(str, candidate, prefix)) {
+                ret = lre_exec_at(capture, re_bytecode,
+                                  get_u32(prefix + LRE_META_ENTRY_OFFSET),
+                                  str->u.str8, candidate, str->len, shift, ctx);
+                if (ret != 0)
+                    return ret;
+            }
+            candidate++;
         }
-        i = candidate + 1;
-        candidate = i;
+        candidate = chunk_end;
+        if (candidate < limit && lre_check_timeout(ctx))
+            return LRE_RET_TIMEOUT;
     }
     return 0;
 }
@@ -48619,6 +48725,48 @@ static int js_regexp_match_quick_check(JSContext *ctx, uint8_t **capture,
     return 0;
 }
 
+typedef struct JSRegExpExecData {
+    const uint8_t *bytecode;
+    const uint8_t *atom;
+    const uint8_t *prefix;
+    const uint8_t *quick_check;
+    int re_flags;
+    BOOL is_atom;
+} JSRegExpExecData;
+
+static force_inline void
+js_regexp_exec_data_init(JSRegExpExecData *d, JSRegExp *re,
+                         int capture_count)
+{
+    d->bytecode = re->bytecode->u.str8;
+    d->re_flags = lre_get_flags(d->bytecode);
+    d->atom = js_regexp_get_atom(d->re_flags, capture_count, re);
+    d->is_atom = d->atom != NULL;
+    d->prefix = d->is_atom ? NULL : js_regexp_get_prefix(re);
+    d->quick_check = (d->is_atom || d->prefix) ? NULL :
+        js_regexp_get_quick_check(re);
+}
+
+static force_inline int
+js_regexp_match(JSContext *ctx, uint8_t **capture,
+                const JSRegExpExecData *d, JSRegExp *re,
+                JSString *str, int start_index)
+{
+    if (d->is_atom) {
+        return js_regexp_match_atom(ctx, capture, str, d->atom, re->pattern,
+                                    start_index);
+    } else if (d->prefix) {
+        return js_regexp_match_prefix(ctx, capture, d->bytecode, d->prefix,
+                                      str, start_index);
+    } else if (d->quick_check) {
+        return js_regexp_match_quick_check(ctx, capture, d->bytecode,
+                                           d->quick_check, str, start_index);
+    } else {
+        return lre_exec(capture, d->bytecode, str->u.str8, start_index,
+                        str->len, str->is_wide_char, ctx);
+    }
+}
+
 static JSValue js_regexp_exec(JSContext *ctx, JSValueConst this_val,
                               int argc, JSValueConst *argv)
 {
@@ -48634,8 +48782,7 @@ static JSValue js_regexp_exec(JSContext *ctx, JSValueConst this_val,
     const char *group_name_ptr;
     JSObject *p_obj;
     JSAtom group_name;
-    BOOL is_atom;
-    const uint8_t *atom, *prefix, *quick_check;
+    JSRegExpExecData exec_data;
     
     if (!re)
         return JS_EXCEPTION;
@@ -48668,26 +48815,13 @@ static JSValue js_regexp_exec(JSContext *ctx, JSValueConst this_val,
             goto fail;
     }
     capture_count = lre_get_capture_count(re_bytecode);
-    atom = js_regexp_get_atom(re_flags, capture_count, re);
-    is_atom = (atom != NULL);
-    prefix = is_atom ? NULL : js_regexp_get_prefix(re);
-    quick_check = (is_atom || prefix) ? NULL : js_regexp_get_quick_check(re);
+    js_regexp_exec_data_init(&exec_data, re, capture_count);
     shift = str->is_wide_char;
     str_buf = str->u.str8;
     if (last_index > str->len) {
         rc = 2;
-    } else if (is_atom) {
-        rc = js_regexp_match_atom(capture, str, atom, re->pattern, last_index);
-    } else if (prefix) {
-        rc = js_regexp_match_prefix(ctx, capture, re_bytecode, prefix, str,
-                                    last_index);
-    } else if (quick_check) {
-        rc = js_regexp_match_quick_check(ctx, capture, re_bytecode,
-                                         quick_check, str, last_index);
     } else {
-        rc = lre_exec(capture, re_bytecode,
-                      str_buf, last_index, str->len,
-                      shift, ctx);
+        rc = js_regexp_match(ctx, capture, &exec_data, re, str, last_index);
     }
     if (rc != 1) {
         if (rc >= 0) {
@@ -48713,7 +48847,7 @@ static JSValue js_regexp_exec(JSContext *ctx, JSValueConst this_val,
                 goto fail;
         }
         prop_flags = JS_PROP_C_W_E | JS_PROP_THROW;
-        if (is_atom && !(re_flags & LRE_FLAG_INDICES)) {
+        if (exec_data.is_atom && !(re_flags & LRE_FLAG_INDICES)) {
             JSValue val;
             int start;
 
@@ -48734,11 +48868,13 @@ static JSValue js_regexp_exec(JSContext *ctx, JSValueConst this_val,
             if (!p_obj->u.array.u.values)
                 goto fail;
             p_obj->u.array.u1.size = 1;
-            if (atom[LRE_META_FLAGS_OFFSET] & LRE_META_FLAG_SOURCE) {
+            if (exec_data.atom[LRE_META_FLAGS_OFFSET] &
+                LRE_META_FLAG_SOURCE) {
                 val = JS_DupValue(ctx, JS_MKPTR(JS_TAG_STRING, re->pattern));
             } else {
                 val = js_sub_string(ctx, str, start,
-                                    start + get_u32(atom + LRE_META_LENGTH_OFFSET));
+                                    start + get_u32(exec_data.atom +
+                                                    LRE_META_LENGTH_OFFSET));
                 if (JS_IsException(val))
                     goto fail;
             }
@@ -48905,8 +49041,8 @@ static JSValue js_regexp_replace(JSContext *ctx, JSValueConst this_val, JSValueC
     StringBuffer b_s, *b = &b_s;
     JSString *rp = JS_VALUE_GET_STRING(rep_val);
     const char *group_name_ptr;
-    BOOL fullUnicode, has_match, simple_replace, is_atom;
-    const uint8_t *atom, *prefix, *quick_check;
+    BOOL fullUnicode, has_match, simple_replace;
+    JSRegExpExecData exec_data;
     
     if (!re)
         return JS_EXCEPTION;
@@ -48941,10 +49077,7 @@ static JSValue js_regexp_replace(JSContext *ctx, JSValueConst this_val, JSValueC
             goto fail;
     }
     capture_count = lre_get_capture_count(re_bytecode);
-    atom = js_regexp_get_atom(re_flags, capture_count, re);
-    is_atom = (atom != NULL);
-    prefix = is_atom ? NULL : js_regexp_get_prefix(re);
-    quick_check = (is_atom || prefix) ? NULL : js_regexp_get_quick_check(re);
+    js_regexp_exec_data_init(&exec_data, re, capture_count);
     fullUnicode = ((re_flags & (LRE_FLAG_UNICODE | LRE_FLAG_UNICODE_SETS)) != 0);
     shift = str->is_wide_char;
     str_buf = str->u.str8;
@@ -48954,18 +49087,9 @@ static JSValue js_regexp_replace(JSContext *ctx, JSValueConst this_val, JSValueC
     for (;;) {
         if (last_index > str->len) {
             ret = 0;
-        } else if (is_atom) {
-            ret = js_regexp_match_atom(capture, str, atom, re->pattern,
-                                       last_index);
-        } else if (prefix) {
-            ret = js_regexp_match_prefix(ctx, capture, re_bytecode, prefix,
-                                         str, last_index);
-        } else if (quick_check) {
-            ret = js_regexp_match_quick_check(ctx, capture, re_bytecode,
-                                              quick_check, str, last_index);
         } else {
-            ret = lre_exec(capture, re_bytecode,
-                           str_buf, last_index, str->len, shift, ctx);
+            ret = js_regexp_match(ctx, capture, &exec_data, re, str,
+                                  last_index);
         }
         if (ret != 1) {
             if (ret >= 0) {

--- a/quickjs.c
+++ b/quickjs.c
@@ -748,6 +748,7 @@ typedef struct JSForInIterator {
 typedef struct JSRegExp {
     JSString *pattern;
     JSString *bytecode; /* also contains the flags */
+    const uint8_t *metadata; /* validated view owned by bytecode */
 } JSRegExp;
 
 typedef struct JSProxyData {
@@ -1070,7 +1071,7 @@ struct JSObject {
             } u;
             uint32_t count; /* <= 2^31-1. 0 for a detached typed array */
         } array;    /* 12/20 bytes */
-        JSRegExp regexp;    /* JS_CLASS_REGEXP: 8/16 bytes */
+        JSRegExp regexp;    /* JS_CLASS_REGEXP: 12/24 bytes */
         JSValue object_data;    /* for JS_SetObjectData(): 8/16/16 bytes */
         JSGlobalObject global_object;
     } u;
@@ -37502,7 +37503,7 @@ typedef enum BCTagEnum {
     BC_TAG_OBJECT_REFERENCE,
 } BCTagEnum;
 
-#define BC_VERSION 5
+#define BC_VERSION 6
 
 typedef struct BCWriterState {
     JSContext *ctx;
@@ -38510,6 +38511,12 @@ static int bc_get_leb128_u16(BCReaderState *s, uint16_t *pval)
         *pval = 0;
         return -1;
     }
+    if (val > UINT16_MAX) {
+        *pval = 0;
+        if (!s->error_state)
+            JS_ThrowSyntaxError(s->ctx, "invalid bytecode integer");
+        return s->error_state = -1;
+    }
     *pval = val;
     return 0;
 }
@@ -38612,6 +38619,31 @@ static uint32_t bc_get_flags(uint32_t flags, int *pidx, int n)
     return val;
 }
 
+static int js_check_function_bytecode_bounds(JSContext *ctx,
+                                             const uint8_t *bc_buf,
+                                             uint32_t bc_len)
+{
+    uint32_t pos;
+
+    if (bc_len == 0)
+        return JS_ThrowSyntaxError(ctx, "empty function bytecode"), -1;
+    pos = 0;
+    while (pos < bc_len) {
+        const JSOpCode *oi;
+        int op = bc_buf[pos];
+
+        if (op == OP_invalid || op >= OP_COUNT)
+            return JS_ThrowSyntaxError(ctx, "invalid function opcode"), -1;
+        oi = &short_opcode_info(op);
+        if (oi->size == 0 || oi->size > bc_len - pos)
+            return JS_ThrowSyntaxError(ctx, "truncated function opcode"), -1;
+        pos += oi->size;
+    }
+    if (pos != bc_len)
+        return JS_ThrowSyntaxError(ctx, "invalid function bytecode length"), -1;
+    return 0;
+}
+
 static int JS_ReadFunctionBytecode(BCReaderState *s, JSFunctionBytecode *b,
                                    int byte_code_offset, uint32_t bc_len)
 {
@@ -38633,6 +38665,12 @@ static int JS_ReadFunctionBytecode(BCReaderState *s, JSFunctionBytecode *b,
     }
     b->byte_code_buf = bc_buf;
 
+    if (js_check_function_bytecode_bounds(s->ctx, bc_buf, bc_len)) {
+        /* No atom reference was fixed up yet, so the buffer is not safe to
+           scan during cleanup. */
+        b->byte_code_len = 0;
+        return -1;
+    }
     if (is_be())
         bc_byte_swap(bc_buf, bc_len);
 
@@ -38668,6 +38706,267 @@ static int JS_ReadFunctionBytecode(BCReaderState *s, JSFunctionBytecode *b,
         pos += len;
     }
     return 0;
+}
+
+static int js_get_pushed_constant(JSFunctionBytecode *b, int pos,
+                                  uint32_t *pidx)
+{
+    const uint8_t *bc_buf = b->byte_code_buf;
+
+    if (pos < 0)
+        return -1;
+    if (bc_buf[pos] == OP_push_const) {
+        *pidx = get_u32(bc_buf + pos + 1);
+    } else if (bc_buf[pos] == OP_push_const8) {
+        *pidx = bc_buf[pos + 1];
+    } else {
+        return -1;
+    }
+    if (*pidx >= b->cpool_count)
+        return -1;
+    return 0;
+}
+
+static int js_validate_regexp_constant(JSContext *ctx, JSFunctionBytecode *b,
+                                       int pattern_pos, int bytecode_pos)
+{
+    static const int source_flag_mask =
+        LRE_FLAG_GLOBAL | LRE_FLAG_IGNORECASE | LRE_FLAG_MULTILINE |
+        LRE_FLAG_DOTALL | LRE_FLAG_UNICODE | LRE_FLAG_STICKY |
+        LRE_FLAG_INDICES | LRE_FLAG_UNICODE_SETS;
+    JSValueConst pattern_val, bytecode_val;
+    JSString *bytecode_str;
+    uint8_t *trusted_bytecode;
+    const char *pattern_buf;
+    uint32_t pattern_idx, bytecode_idx;
+    size_t pattern_len;
+    int source_flags, serialized_flags, trusted_len;
+    char error_msg[128];
+
+    if (js_get_pushed_constant(b, pattern_pos, &pattern_idx) ||
+        js_get_pushed_constant(b, bytecode_pos, &bytecode_idx)) {
+        JS_ThrowSyntaxError(ctx, "invalid regexp constant operands");
+        return -1;
+    }
+    pattern_val = b->cpool[pattern_idx];
+    bytecode_val = b->cpool[bytecode_idx];
+    if (!JS_IsString(pattern_val) || !JS_IsString(bytecode_val)) {
+        JS_ThrowSyntaxError(ctx, "regexp constants must be strings");
+        return -1;
+    }
+    bytecode_str = JS_VALUE_GET_STRING(bytecode_val);
+    if (bytecode_str->is_wide_char) {
+        JS_ThrowSyntaxError(ctx, "regexp bytecode must be an 8 bit string");
+        return -1;
+    }
+    if (lre_validate_bytecode(bytecode_str->u.str8, bytecode_str->len,
+                              error_msg, sizeof(error_msg), ctx)) {
+        JS_ThrowSyntaxError(ctx, "invalid regexp bytecode: %s", error_msg);
+        return -1;
+    }
+
+    serialized_flags = lre_get_flags(bytecode_str->u.str8);
+    source_flags = serialized_flags & source_flag_mask;
+    pattern_buf = JS_ToCStringLen2(ctx, &pattern_len, pattern_val,
+                                  !(source_flags & (LRE_FLAG_UNICODE |
+                                                    LRE_FLAG_UNICODE_SETS)));
+    if (!pattern_buf)
+        return -1;
+    trusted_bytecode = lre_compile(&trusted_len, error_msg, sizeof(error_msg),
+                                   pattern_buf, pattern_len, source_flags, ctx);
+    JS_FreeCString(ctx, pattern_buf);
+    if (!trusted_bytecode) {
+        JS_ThrowSyntaxError(ctx, "invalid regexp pattern: %s", error_msg);
+        return -1;
+    }
+
+    /* Older payloads may omit the optional ATOM optimization marker. */
+    if (!(serialized_flags & LRE_FLAG_ATOM)) {
+        put_u16(trusted_bytecode,
+                lre_get_flags(trusted_bytecode) & ~LRE_FLAG_ATOM);
+    }
+    if (trusted_len != bytecode_str->len ||
+        memcmp(trusted_bytecode, bytecode_str->u.str8, trusted_len) != 0) {
+        js_free(ctx, trusted_bytecode);
+        JS_ThrowSyntaxError(ctx, "regexp bytecode does not match its pattern");
+        return -1;
+    }
+    js_free(ctx, trusted_bytecode);
+    return 0;
+}
+
+static int js_check_bytecode_target(JSContext *ctx, const uint8_t *boundaries,
+                                    int bytecode_len, int base, int32_t diff)
+{
+    int64_t target = (int64_t)base + diff;
+
+    if (target < 0 || target >= bytecode_len || !boundaries[target]) {
+        JS_ThrowSyntaxError(ctx, "invalid function bytecode jump");
+        return -1;
+    }
+    return 0;
+}
+
+static int js_validate_loaded_function_bytecode(JSContext *ctx,
+                                                JSFunctionBytecode *b)
+{
+    JSFunctionDef fd_s, *fd = &fd_s;
+    const uint8_t *bc_buf = b->byte_code_buf;
+    uint8_t *boundaries;
+    int pos, prev_pos, prev_prev_pos, computed_stack_size;
+
+    boundaries = js_mallocz(ctx, b->byte_code_len);
+    if (!boundaries)
+        return -1;
+    pos = 0;
+    while (pos < b->byte_code_len) {
+        int op = bc_buf[pos];
+        boundaries[pos] = 1;
+        pos += short_opcode_info(op).size;
+    }
+
+    memset(fd, 0, sizeof(*fd));
+    fd->byte_code.buf = (uint8_t *)bc_buf;
+    fd->byte_code.size = b->byte_code_len;
+    if (compute_stack_size(ctx, fd, &computed_stack_size))
+        goto fail;
+    if (computed_stack_size != b->stack_size) {
+        JS_ThrowSyntaxError(ctx, "invalid function bytecode stack size");
+        goto fail;
+    }
+
+    prev_pos = -1;
+    prev_prev_pos = -1;
+    pos = 0;
+    while (pos < b->byte_code_len) {
+        const JSOpCode *oi;
+        uint32_t idx;
+        int op = bc_buf[pos];
+        int operand_index = -1;
+
+        oi = &short_opcode_info(op);
+        switch(oi->fmt) {
+        case OP_FMT_const:
+            idx = get_u32(bc_buf + pos + 1);
+            if (idx >= b->cpool_count) {
+                JS_ThrowSyntaxError(ctx, "invalid constant pool index");
+                goto fail;
+            }
+            break;
+        case OP_FMT_const8:
+            idx = bc_buf[pos + 1];
+            if (idx >= b->cpool_count) {
+                JS_ThrowSyntaxError(ctx, "invalid constant pool index");
+                goto fail;
+            }
+            break;
+        case OP_FMT_loc:
+            operand_index = get_u16(bc_buf + pos + 1);
+            if (operand_index >= b->var_count)
+                goto invalid_local;
+            break;
+        case OP_FMT_loc8:
+            operand_index = bc_buf[pos + 1];
+            if (operand_index >= b->var_count)
+                goto invalid_local;
+            break;
+        case OP_FMT_none_loc:
+            operand_index = (op - OP_get_loc0) % 4;
+            if (operand_index >= b->var_count)
+                goto invalid_local;
+            break;
+        case OP_FMT_arg:
+            operand_index = get_u16(bc_buf + pos + 1);
+            if (operand_index >= b->arg_count)
+                goto invalid_argument;
+            break;
+        case OP_FMT_none_arg:
+            operand_index = (op - OP_get_arg0) % 4;
+            if (operand_index >= b->arg_count)
+                goto invalid_argument;
+            break;
+        case OP_FMT_var_ref:
+            operand_index = get_u16(bc_buf + pos + 1);
+            if (operand_index >= b->closure_var_count)
+                goto invalid_var_ref;
+            break;
+        case OP_FMT_none_var_ref:
+            operand_index = (op - OP_get_var_ref0) % 4;
+            if (operand_index >= b->closure_var_count)
+                goto invalid_var_ref;
+            break;
+        case OP_FMT_label:
+            if (js_check_bytecode_target(ctx, boundaries, b->byte_code_len,
+                                         pos + 1, get_i32(bc_buf + pos + 1)))
+                goto fail;
+            break;
+        case OP_FMT_label8:
+            if (js_check_bytecode_target(ctx, boundaries, b->byte_code_len,
+                                         pos + 1, get_i8(bc_buf + pos + 1)))
+                goto fail;
+            break;
+        case OP_FMT_label16:
+            if (js_check_bytecode_target(ctx, boundaries, b->byte_code_len,
+                                         pos + 1, get_i16(bc_buf + pos + 1)))
+                goto fail;
+            break;
+        case OP_FMT_atom_label_u8:
+        case OP_FMT_atom_label_u16:
+            if (js_check_bytecode_target(ctx, boundaries, b->byte_code_len,
+                                         pos + 5, get_i32(bc_buf + pos + 5)))
+                goto fail;
+            break;
+        case OP_FMT_label_u16:
+            if (js_check_bytecode_target(ctx, boundaries, b->byte_code_len,
+                                         pos + 1, get_i32(bc_buf + pos + 1)))
+                goto fail;
+            break;
+        default:
+            break;
+        }
+
+        if (op == OP_fclosure || op == OP_fclosure8) {
+            if (op == OP_fclosure)
+                idx = get_u32(bc_buf + pos + 1);
+            else
+                idx = bc_buf[pos + 1];
+            if (idx >= b->cpool_count ||
+                JS_VALUE_GET_TAG(b->cpool[idx]) != JS_TAG_FUNCTION_BYTECODE) {
+                JS_ThrowSyntaxError(ctx, "invalid closure constant");
+                goto fail;
+            }
+        } else if (op == OP_make_loc_ref) {
+            if (get_u16(bc_buf + pos + 5) >= b->var_count)
+                goto invalid_local;
+        } else if (op == OP_make_arg_ref) {
+            if (get_u16(bc_buf + pos + 5) >= b->arg_count)
+                goto invalid_argument;
+        } else if (op == OP_make_var_ref_ref) {
+            if (get_u16(bc_buf + pos + 5) >= b->closure_var_count)
+                goto invalid_var_ref;
+        } else if (op == OP_regexp) {
+            if (js_validate_regexp_constant(ctx, b, prev_prev_pos, prev_pos))
+                goto fail;
+        }
+
+        prev_prev_pos = prev_pos;
+        prev_pos = pos;
+        pos += oi->size;
+    }
+    js_free(ctx, boundaries);
+    return 0;
+
+ invalid_local:
+    JS_ThrowSyntaxError(ctx, "invalid local variable index");
+    goto fail;
+ invalid_argument:
+    JS_ThrowSyntaxError(ctx, "invalid argument index");
+    goto fail;
+ invalid_var_ref:
+    JS_ThrowSyntaxError(ctx, "invalid variable reference index");
+ fail:
+    js_free(ctx, boundaries);
+    return -1;
 }
 
 static JSValue JS_ReadBigInt(BCReaderState *s)
@@ -38793,6 +39092,15 @@ static JSValue JS_ReadFunctionTag(BCReaderState *s)
         goto fail;
     if (bc_get_leb128_int(s, &local_count))
         goto fail;
+    if (bc.closure_var_count < 0 || bc.cpool_count < 0 ||
+        bc.byte_code_len <= 0 || local_count < 0 ||
+        bc.defined_arg_count > bc.arg_count ||
+        (local_count != 0 &&
+         local_count != (int)bc.arg_count + bc.var_count) ||
+        bc.var_ref_count > (uint32_t)bc.arg_count + bc.var_count) {
+        JS_ThrowSyntaxError(ctx, "invalid function bytecode header");
+        goto fail;
+    }
 
     if (bc.has_debug) {
         function_size = sizeof(*b);
@@ -38936,6 +39244,8 @@ static JSValue JS_ReadFunctionTag(BCReaderState *s)
         }
         bc_read_trace(s, "}\n");
     }
+    if (js_validate_loaded_function_bytecode(ctx, b))
+        goto fail;
     b->realm = JS_DupContext(ctx);
     return obj;
  fail:
@@ -45542,12 +45852,7 @@ static JSValue js_string_concat(JSContext *ctx, JSValueConst this_val,
 
 static int string_cmp(JSString *p1, JSString *p2, int x1, int x2, int len)
 {
-    int i, c1, c2;
-    for (i = 0; i < len; i++) {
-        if ((c1 = string_get(p1, x1 + i)) != (c2 = string_get(p2, x2 + i)))
-            return c1 - c2;
-    }
-    return 0;
+    return js_string_memcmp(p1, x1, p2, x2, len);
 }
 
 static int string_indexof_char(JSString *p, int c, int from)
@@ -45561,10 +45866,11 @@ static int string_indexof_char(JSString *p, int c, int from)
         }
     } else {
         if ((c & ~0xff) == 0) {
-            for (i = from; i < len; i++) {
-                if (p->u.str8[i] == (uint8_t)c)
-                    return i;
-            }
+            const uint8_t *ptr;
+
+            ptr = memchr(p->u.str8 + from, c, len - from);
+            if (ptr)
+                return ptr - p->u.str8;
         }
     }
     return -1;
@@ -47647,6 +47953,7 @@ static JSValue JS_NewRegexp(JSContext *ctx, JSValue pattern, JSValue bc)
     JSProperty props[1];
     JSObject *p;
     JSRegExp *re;
+    LREMetadata metadata;
 
     /* sanity check */
     if (unlikely(JS_VALUE_GET_TAG(bc) != JS_TAG_STRING ||
@@ -47662,6 +47969,12 @@ static JSValue JS_NewRegexp(JSContext *ctx, JSValue pattern, JSValue bc)
     re = &p->u.regexp;
     re->pattern = JS_VALUE_GET_STRING(pattern);
     re->bytecode = JS_VALUE_GET_STRING(bc);
+    if (!re->bytecode->is_wide_char &&
+        lre_get_metadata(re->bytecode->u.str8, re->bytecode->len,
+                         &metadata) == 1)
+        re->metadata = metadata.payload - LRE_META_HEADER_LEN;
+    else
+        re->metadata = NULL;
     return obj;
  fail:
     JS_FreeValue(ctx, bc);
@@ -47676,6 +47989,7 @@ static JSValue js_regexp_set_internal(JSContext *ctx,
 {
     JSObject *p;
     JSRegExp *re;
+    LREMetadata metadata;
 
     /* sanity check */
     if (unlikely(JS_VALUE_GET_TAG(bc) != JS_TAG_STRING ||
@@ -47691,6 +48005,12 @@ static JSValue js_regexp_set_internal(JSContext *ctx,
     re = &p->u.regexp;
     re->pattern = JS_VALUE_GET_STRING(pattern);
     re->bytecode = JS_VALUE_GET_STRING(bc);
+    if (!re->bytecode->is_wide_char &&
+        lre_get_metadata(re->bytecode->u.str8, re->bytecode->len,
+                         &metadata) == 1)
+        re->metadata = metadata.payload - LRE_META_HEADER_LEN;
+    else
+        re->metadata = NULL;
     /* Note: cannot fail because the field is preallocated */
     JS_DefinePropertyValue(ctx, obj, JS_ATOM_lastIndex, JS_NewInt32(ctx, 0),
                            JS_PROP_WRITABLE);
@@ -48105,6 +48425,200 @@ static force_inline int js_regexp_set_lastIndex(JSContext *ctx, JSValueConst thi
     return 0;
 }
 
+#define JS_REGEXP_CAPTURE_STACK_SIZE 16
+
+static force_inline const uint8_t *
+js_regexp_get_atom(int re_flags, int capture_count, const JSRegExp *re)
+{
+    const uint8_t *p = re->metadata;
+
+    if (!(re_flags & LRE_FLAG_ATOM) || capture_count != 1 ||
+        re->pattern->len == 0 || !p)
+        return NULL;
+    return p;
+}
+
+static force_inline const uint8_t *js_regexp_get_prefix(const JSRegExp *re)
+{
+    const uint8_t *p = re->metadata;
+
+    if (!p || p[LRE_META_KIND_OFFSET] != LRE_META_PREFIX ||
+        get_u32(p + LRE_META_LENGTH_OFFSET) < 3 ||
+        get_u32(p + LRE_META_LENGTH_OFFSET) > INT_MAX)
+        return NULL;
+    return p;
+}
+
+static force_inline const uint8_t *js_regexp_get_quick_check(const JSRegExp *re)
+{
+    const uint8_t *p = re->metadata;
+
+    if (!p || p[LRE_META_KIND_OFFSET] != LRE_META_QUICK_CHECK ||
+        get_u32(p + LRE_META_LENGTH_OFFSET) < 3 ||
+        get_u32(p + LRE_META_LENGTH_OFFSET) > LRE_QUICK_CHECK_MAX)
+        return NULL;
+    return p;
+}
+
+static force_inline int js_regexp_atom_char(const uint8_t *atom, int index)
+{
+    const uint8_t *payload = atom + LRE_META_HEADER_LEN;
+
+    if (atom[LRE_META_ENCODING_OFFSET])
+        return get_u16(payload + index * 2);
+    return payload[index];
+}
+
+static force_inline BOOL js_regexp_source_starts_at(JSString *str, int start,
+                                                    JSString *pattern)
+{
+    if (str->is_wide_char == pattern->is_wide_char) {
+        if (str->is_wide_char) {
+            return str->u.str16[start] == pattern->u.str16[0] &&
+                   memcmp(str->u.str16 + start + 1, pattern->u.str16 + 1,
+                          (pattern->len - 1) * sizeof(pattern->u.str16[0])) == 0;
+        } else {
+            return str->u.str8[start] == pattern->u.str8[0] &&
+                   memcmp(str->u.str8 + start + 1, pattern->u.str8 + 1,
+                          pattern->len - 1) == 0;
+        }
+    }
+    return string_get(str, start) == string_get(pattern, 0) &&
+           js_string_memcmp(str, start + 1, pattern, 1,
+                            pattern->len - 1) == 0;
+}
+
+static force_inline BOOL js_regexp_atom_starts_at(JSString *str, int start,
+                                                  const uint8_t *atom)
+{
+    const uint8_t *payload = atom + LRE_META_HEADER_LEN;
+    int encoding = atom[LRE_META_ENCODING_OFFSET];
+    int i, len = get_u32(atom + LRE_META_LENGTH_OFFSET);
+
+    if (len > str->len - start)
+        return FALSE;
+    if (str->is_wide_char == encoding) {
+        return memcmp(str->u.str8 + (start << encoding), payload,
+                      len << encoding) == 0;
+    }
+    for(i = 0; i < len; i++) {
+        if (string_get(str, start + i) != js_regexp_atom_char(atom, i))
+            return FALSE;
+    }
+    return TRUE;
+}
+
+static force_inline int js_regexp_match_atom(uint8_t **capture, JSString *str,
+                                             const uint8_t *atom,
+                                             JSString *pattern,
+                                             int start_index)
+{
+    int c, i, start, shift, len;
+
+    if (atom[LRE_META_FLAGS_OFFSET] & LRE_META_FLAG_SOURCE) {
+        len = pattern->len;
+        if (start_index + pattern->len <= str->len &&
+            js_regexp_source_starts_at(str, start_index, pattern)) {
+            start = start_index;
+        } else {
+            start = string_indexof(str, pattern, start_index);
+        }
+    } else if (js_regexp_atom_starts_at(str, start_index, atom)) {
+        len = get_u32(atom + LRE_META_LENGTH_OFFSET);
+        start = start_index;
+    } else {
+        len = get_u32(atom + LRE_META_LENGTH_OFFSET);
+        start = -1;
+        c = js_regexp_atom_char(atom, 0);
+        for(i = start_index; i + len <= str->len; i = start + 1) {
+            start = string_indexof_char(str, c, i);
+            if (start < 0 || start + len > str->len) {
+                start = -1;
+                break;
+            }
+            if (js_regexp_atom_starts_at(str, start, atom))
+                break;
+        }
+    }
+    if (start < 0)
+        return 0;
+    shift = str->is_wide_char;
+    capture[0] = str->u.str8 + (start << shift);
+    capture[1] = str->u.str8 + ((start + len) << shift);
+    return 1;
+}
+
+static int js_regexp_match_prefix(JSContext *ctx, uint8_t **capture,
+                                  const uint8_t *re_bytecode,
+                                  const uint8_t *prefix, JSString *str,
+                                  int start_index)
+{
+    int c, candidate, i, ret, attempts, len, shift;
+
+    len = get_u32(prefix + LRE_META_LENGTH_OFFSET);
+    shift = str->is_wide_char;
+    c = js_regexp_atom_char(prefix, 0);
+    candidate = start_index;
+    attempts = 0;
+    while (candidate + len <= str->len) {
+        candidate = string_indexof_char(str, c, candidate);
+        if (candidate < 0 || candidate + len > str->len)
+            return 0;
+        if (js_regexp_atom_starts_at(str, candidate, prefix)) {
+            ret = lre_exec_at(capture, re_bytecode,
+                              get_u32(prefix + LRE_META_ENTRY_OFFSET),
+                              str->u.str8, candidate, str->len, shift, ctx);
+            if (ret != 0)
+                return ret;
+            if ((++attempts & 1023) == 0 && lre_check_timeout(ctx))
+                return LRE_RET_TIMEOUT;
+        }
+        i = candidate + 1;
+        candidate = i;
+    }
+    return 0;
+}
+
+static int js_regexp_match_quick_check(JSContext *ctx, uint8_t **capture,
+                                       const uint8_t *re_bytecode,
+                                       const uint8_t *quick_check,
+                                       JSString *str, int start_index)
+{
+    const uint8_t *payload, *record;
+    uint32_t c, count, mask, value;
+    int attempts, candidate, i, last_offset, ret, shift;
+
+    count = get_u32(quick_check + LRE_META_LENGTH_OFFSET);
+    payload = quick_check + LRE_META_HEADER_LEN;
+    record = payload + (count - 1) * LRE_QUICK_CHECK_RECORD_SIZE;
+    last_offset = get_u16(record + LRE_QUICK_CHECK_OFFSET);
+    shift = str->is_wide_char;
+    attempts = 0;
+    for(candidate = start_index;
+        candidate + last_offset < str->len;
+        candidate++) {
+        for(i = 0; i < (int)count; i++) {
+            record = payload + i * LRE_QUICK_CHECK_RECORD_SIZE;
+            c = string_get(str, candidate +
+                           get_u16(record + LRE_QUICK_CHECK_OFFSET));
+            value = get_u16(record + LRE_QUICK_CHECK_VALUE);
+            mask = get_u16(record + LRE_QUICK_CHECK_MASK);
+            if ((c & mask) != value)
+                break;
+        }
+        if (i == (int)count) {
+            ret = lre_exec_at(capture, re_bytecode,
+                              get_u32(quick_check + LRE_META_ENTRY_OFFSET),
+                              str->u.str8, candidate, str->len, shift, ctx);
+            if (ret != 0)
+                return ret;
+        }
+        if ((++attempts & 1023) == 0 && lre_check_timeout(ctx))
+            return LRE_RET_TIMEOUT;
+    }
+    return 0;
+}
+
 static JSValue js_regexp_exec(JSContext *ctx, JSValueConst this_val,
                               int argc, JSValueConst *argv)
 {
@@ -48113,12 +48627,15 @@ static JSValue js_regexp_exec(JSContext *ctx, JSValueConst this_val,
     JSValue t, ret, str_val, obj, groups;
     JSValue indices, indices_groups;
     uint8_t *re_bytecode;
+    uint8_t *capture_stack[JS_REGEXP_CAPTURE_STACK_SIZE];
     uint8_t **capture, *str_buf;
     int rc, capture_count, shift, i, re_flags, alloc_count;
     int64_t last_index;
     const char *group_name_ptr;
     JSObject *p_obj;
     JSAtom group_name;
+    BOOL is_atom;
+    const uint8_t *atom, *prefix, *quick_check;
     
     if (!re)
         return JS_EXCEPTION;
@@ -48132,7 +48649,7 @@ static JSValue js_regexp_exec(JSContext *ctx, JSValueConst this_val,
     groups = JS_UNDEFINED;
     indices = JS_UNDEFINED;
     indices_groups = JS_UNDEFINED;
-    capture = NULL;
+    capture = capture_stack;
     group_name = JS_ATOM_NULL;
     
     if (js_regexp_get_lastIndex(ctx, &last_index, this_val))
@@ -48145,16 +48662,28 @@ static JSValue js_regexp_exec(JSContext *ctx, JSValueConst this_val,
     }
     str = JS_VALUE_GET_STRING(str_val);
     alloc_count = lre_get_alloc_count(re_bytecode);
-    if (alloc_count > 0) {
+    if (alloc_count > countof(capture_stack)) {
         capture = js_malloc(ctx, sizeof(capture[0]) * alloc_count);
         if (!capture)
             goto fail;
     }
     capture_count = lre_get_capture_count(re_bytecode);
+    atom = js_regexp_get_atom(re_flags, capture_count, re);
+    is_atom = (atom != NULL);
+    prefix = is_atom ? NULL : js_regexp_get_prefix(re);
+    quick_check = (is_atom || prefix) ? NULL : js_regexp_get_quick_check(re);
     shift = str->is_wide_char;
     str_buf = str->u.str8;
     if (last_index > str->len) {
         rc = 2;
+    } else if (is_atom) {
+        rc = js_regexp_match_atom(capture, str, atom, re->pattern, last_index);
+    } else if (prefix) {
+        rc = js_regexp_match_prefix(ctx, capture, re_bytecode, prefix, str,
+                                    last_index);
+    } else if (quick_check) {
+        rc = js_regexp_match_quick_check(ctx, capture, re_bytecode,
+                                         quick_check, str, last_index);
     } else {
         rc = lre_exec(capture, re_bytecode,
                       str_buf, last_index, str->len,
@@ -48184,7 +48713,41 @@ static JSValue js_regexp_exec(JSContext *ctx, JSValueConst this_val,
                 goto fail;
         }
         prop_flags = JS_PROP_C_W_E | JS_PROP_THROW;
-        group_name_ptr = lre_get_groupnames(re_bytecode);
+        if (is_atom && !(re_flags & LRE_FLAG_INDICES)) {
+            JSValue val;
+            int start;
+
+            start = (capture[0] - str_buf) >> shift;
+            props[0].u.value = JS_NewInt32(ctx, 1); /* length */
+            props[1].u.value = JS_NewInt32(ctx, start); /* index */
+            props[2].u.value = str_val; /* input */
+            props[3].u.value = JS_UNDEFINED; /* groups */
+            str_val = JS_UNDEFINED;
+            obj = JS_NewObjectFromShape(ctx,
+                                        js_dup_shape(ctx->regexp_result_shape),
+                                        JS_CLASS_ARRAY, props);
+            if (JS_IsException(obj))
+                goto fail;
+            p_obj = JS_VALUE_GET_OBJ(obj);
+            p_obj->u.array.u.values =
+                js_malloc(ctx, sizeof(p_obj->u.array.u.values[0]));
+            if (!p_obj->u.array.u.values)
+                goto fail;
+            p_obj->u.array.u1.size = 1;
+            if (atom[LRE_META_FLAGS_OFFSET] & LRE_META_FLAG_SOURCE) {
+                val = JS_DupValue(ctx, JS_MKPTR(JS_TAG_STRING, re->pattern));
+            } else {
+                val = js_sub_string(ctx, str, start,
+                                    start + get_u32(atom + LRE_META_LENGTH_OFFSET));
+                if (JS_IsException(val))
+                    goto fail;
+            }
+            p_obj->u.array.u.values[p_obj->u.array.count++] = val;
+            ret = obj;
+            obj = JS_UNDEFINED;
+            goto fail;
+        }
+        group_name_ptr = lre_get_groupnames(re_bytecode, re->bytecode->len);
         if (group_name_ptr) {
             groups = JS_NewObjectProto(ctx, JS_NULL);
             if (JS_IsException(groups))
@@ -48320,7 +48883,8 @@ fail:
     JS_FreeValue(ctx, str_val);
     JS_FreeValue(ctx, groups);
     JS_FreeValue(ctx, obj);
-    js_free(ctx, capture);
+    if (capture != capture_stack)
+        js_free(ctx, capture);
     return ret;
 }
 
@@ -48333,6 +48897,7 @@ static JSValue js_regexp_replace(JSContext *ctx, JSValueConst this_val, JSValueC
     JSValue str_val;
     uint8_t *re_bytecode;
     int ret;
+    uint8_t *capture_stack[JS_REGEXP_CAPTURE_STACK_SIZE];
     uint8_t **capture, *str_buf;
     int capture_count, alloc_count, shift, re_flags;
     int next_src_pos, start, end;
@@ -48340,18 +48905,19 @@ static JSValue js_regexp_replace(JSContext *ctx, JSValueConst this_val, JSValueC
     StringBuffer b_s, *b = &b_s;
     JSString *rp = JS_VALUE_GET_STRING(rep_val);
     const char *group_name_ptr;
-    BOOL fullUnicode;
+    BOOL fullUnicode, has_match, simple_replace, is_atom;
+    const uint8_t *atom, *prefix, *quick_check;
     
     if (!re)
         return JS_EXCEPTION;
     re_bytecode = re->bytecode->u.str8;
-    group_name_ptr = lre_get_groupnames(re_bytecode);
+    group_name_ptr = lre_get_groupnames(re_bytecode, re->bytecode->len);
     if (group_name_ptr)
         return JS_UNDEFINED; /* group names are not supported yet */
     
     string_buffer_init(ctx, b, 0);
 
-    capture = NULL;
+    capture = capture_stack;
     str_val = JS_ToString(ctx, arg);
     if (JS_IsException(str_val))
         goto fail;
@@ -48369,19 +48935,34 @@ static JSValue js_regexp_replace(JSContext *ctx, JSValueConst this_val, JSValueC
             goto fail;
     }
     alloc_count = lre_get_alloc_count(re_bytecode);
-    if (alloc_count > 0) {
+    if (alloc_count > countof(capture_stack)) {
         capture = js_malloc(ctx, sizeof(capture[0]) * alloc_count);
         if (!capture)
             goto fail;
     }
     capture_count = lre_get_capture_count(re_bytecode);
+    atom = js_regexp_get_atom(re_flags, capture_count, re);
+    is_atom = (atom != NULL);
+    prefix = is_atom ? NULL : js_regexp_get_prefix(re);
+    quick_check = (is_atom || prefix) ? NULL : js_regexp_get_quick_check(re);
     fullUnicode = ((re_flags & (LRE_FLAG_UNICODE | LRE_FLAG_UNICODE_SETS)) != 0);
     shift = str->is_wide_char;
     str_buf = str->u.str8;
     next_src_pos = 0;
+    has_match = FALSE;
+    simple_replace = (string_indexof_char(rp, '$', 0) < 0);
     for (;;) {
         if (last_index > str->len) {
             ret = 0;
+        } else if (is_atom) {
+            ret = js_regexp_match_atom(capture, str, atom, re->pattern,
+                                       last_index);
+        } else if (prefix) {
+            ret = js_regexp_match_prefix(ctx, capture, re_bytecode, prefix,
+                                         str, last_index);
+        } else if (quick_check) {
+            ret = js_regexp_match_quick_check(ctx, capture, re_bytecode,
+                                              quick_check, str, last_index);
         } else {
             ret = lre_exec(capture, re_bytecode,
                            str_buf, last_index, str->len, shift, ctx);
@@ -48404,16 +48985,22 @@ static JSValue js_regexp_replace(JSContext *ctx, JSValueConst this_val, JSValueC
         }
         start = (capture[0] - str_buf) >> shift;
         end = (capture[1] - str_buf) >> shift;
+        has_match = TRUE;
         last_index = end;
         if (next_src_pos < start) {
             if (string_buffer_concat(b, str, next_src_pos, start))
                 goto fail;
         }
         if (rp->len != 0) {
-            if (js_string_GetSubstitution(ctx, b, JS_UNDEFINED, str, start,
-                                          JS_UNDEFINED, JS_UNDEFINED, rep_val,
-                                          capture, capture_count)) {
-                goto fail;
+            if (simple_replace) {
+                if (string_buffer_concat(b, rp, 0, rp->len))
+                    goto fail;
+            } else {
+                if (js_string_GetSubstitution(ctx, b, JS_UNDEFINED, str, start,
+                                              JS_UNDEFINED, JS_UNDEFINED, rep_val,
+                                              capture, capture_count)) {
+                    goto fail;
+                }
             }
         }
         next_src_pos = end;
@@ -48429,14 +49016,22 @@ static JSValue js_regexp_replace(JSContext *ctx, JSValueConst this_val, JSValueC
         }
         last_index = end;
     }
+    if (!has_match) {
+        string_buffer_free(b);
+        if (capture != capture_stack)
+            js_free(ctx, capture);
+        return str_val;
+    }
     if (string_buffer_concat(b, str, next_src_pos, str->len))
         goto fail;
     JS_FreeValue(ctx, str_val);
-    js_free(ctx, capture);
+    if (capture != capture_stack)
+        js_free(ctx, capture);
     return string_buffer_end(b);
 fail:
     JS_FreeValue(ctx, str_val);
-    js_free(ctx, capture);
+    if (capture != capture_stack)
+        js_free(ctx, capture);
     string_buffer_free(b);
     return JS_EXCEPTION;
 }

--- a/tests/microbench.js
+++ b/tests/microbench.js
@@ -993,6 +993,116 @@ function regexp_replace(n)
     return n * 1000;
 }
 
+function regexp_escaped_hex(n)
+{
+    var i, j, r, s = "the quick brown fox jumped over the lazy dog";
+    for(j = 0; j < n; j++) {
+        for(i = 0; i < 1000; i++)
+            r = /\x74he quick brown fox/.exec(s);
+        global_res = r;
+    }
+    return n * 1000;
+}
+
+function regexp_escaped_unicode(n)
+{
+    var i, j, r, s = "the quick brown \u1234x jumped over the lazy dog";
+    for(j = 0; j < n; j++) {
+        for(i = 0; i < 1000; i++)
+            r = /the quick brown \u1234x/.exec(s);
+        global_res = r;
+    }
+    return n * 1000;
+}
+
+function regexp_escaped_dot(n)
+{
+    var i, j, r, s = "the quick.brown fox jumped over the lazy dog";
+    for(j = 0; j < n; j++) {
+        for(i = 0; i < 1000; i++)
+            r = /quick\.brown/.exec(s);
+        global_res = r;
+    }
+    return n * 1000;
+}
+
+function regexp_literal_late(n)
+{
+    var i, j, r, s = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxliteral";
+    for(j = 0; j < n; j++) {
+        for(i = 0; i < 1000; i++)
+            r = /literal/.exec(s);
+        global_res = r;
+    }
+    return n * 1000;
+}
+
+function regexp_literal_miss(n)
+{
+    var i, j, r, s = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+    for(j = 0; j < n; j++) {
+        for(i = 0; i < 1000; i++)
+            r = /literal/.exec(s);
+        global_res = r;
+    }
+    return n * 1000;
+}
+
+function regexp_literal_mixed(n)
+{
+    var i, j, r, s = "\u0100xxxxxxxxxxxxxxxxliteral";
+    for(j = 0; j < n; j++) {
+        for(i = 0; i < 1000; i++)
+            r = /literal/.exec(s);
+        global_res = r;
+    }
+    return n * 1000;
+}
+
+function regexp_prefix_late(n)
+{
+    var i, j, r, s = "xxxxxxxxxxxxxxxxxxxxxxxxabcdef123";
+    for(j = 0; j < n; j++) {
+        for(i = 0; i < 1000; i++)
+            r = /abcdef[0-9]+/.exec(s);
+        global_res = r;
+    }
+    return n * 1000;
+}
+
+function regexp_prefix_miss(n)
+{
+    var i, j, r, s = "abcdefXxxxxxxxxxxxxxxxxxxxxxxxxxx";
+    for(j = 0; j < n; j++) {
+        for(i = 0; i < 1000; i++)
+            r = /abcdef[0-9]+/.exec(s);
+        global_res = r;
+    }
+    return n * 1000;
+}
+
+function regexp_quick_check_late(n)
+{
+    var i, j, r, s = "000000000000000000000000xbcdef";
+    for(j = 0; j < n; j++) {
+        for(i = 0; i < 1000; i++)
+            r = /[a-z]bcdef/.exec(s);
+        global_res = r;
+    }
+    return n * 1000;
+}
+
+function regexp_quick_check_miss(n)
+{
+    var i, j, r, s = "000000000000000000000000xbcdeg";
+    for(j = 0; j < n; j++) {
+        for(i = 0; i < 1000; i++)
+            r = /[a-z]bcdef/.exec(s);
+        global_res = r;
+    }
+    return n * 1000;
+}
+
 function string_length(n)
 {
     var str, sum, j;
@@ -1483,6 +1593,16 @@ function main(argc, argv, g)
         regexp_ascii,
         regexp_utf16,
         regexp_replace,
+        regexp_escaped_hex,
+        regexp_escaped_unicode,
+        regexp_escaped_dot,
+        regexp_literal_late,
+        regexp_literal_miss,
+        regexp_literal_mixed,
+        regexp_prefix_late,
+        regexp_prefix_miss,
+        regexp_quick_check_late,
+        regexp_quick_check_miss,
         string_length,
         string_build1,
         string_build1x,

--- a/tests/qbc_regexp_mutator.c
+++ b/tests/qbc_regexp_mutator.c
@@ -1,0 +1,238 @@
+/* Test-only QBC mutator for RegExp validation coverage. */
+
+#include <errno.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "cutils.h"
+#include "libregexp.h"
+
+#define QBC_HEADER_SIZE 64
+#define QBC_PAYLOAD_SIZE_OFFSET 44
+#define QBC_CHECKSUM_OFFSET 52
+
+#define SHORT_OPCODES 1
+
+enum {
+#define FMT(f)
+#define DEF(id, size, n_pop, n_push, f) TEST_OP_ ## id,
+#define def(id, size, n_pop, n_push, f)
+#include "quickjs-opcode.h"
+#undef def
+#undef DEF
+#undef FMT
+    TEST_OP_COUNT,
+};
+
+int lre_check_stack_overflow(void *opaque, size_t alloca_size)
+{
+    return 0;
+}
+
+int lre_check_timeout(void *opaque)
+{
+    return 0;
+}
+
+void *lre_realloc(void *opaque, void *ptr, size_t size)
+{
+    return realloc(ptr, size);
+}
+
+static uint64_t qbc_checksum(const uint8_t *buf, size_t len)
+{
+    uint64_t h = UINT64_C(1469598103934665603);
+    size_t i;
+
+    for(i = 0; i < len; i++) {
+        h ^= buf[i];
+        h *= UINT64_C(1099511628211);
+    }
+    return h;
+}
+
+static void die(const char *message)
+{
+    fprintf(stderr, "qbc_regexp_mutator: %s\n", message);
+    exit(1);
+}
+
+static uint8_t *read_file(const char *filename, size_t *plen)
+{
+    FILE *f;
+    uint8_t *buf;
+    long len = 0;
+
+    f = fopen(filename, "rb");
+    if (!f)
+        die(strerror(errno));
+    if (fseek(f, 0, SEEK_END) || (len = ftell(f)) < 0 ||
+        fseek(f, 0, SEEK_SET)) {
+        fclose(f);
+        die("could not determine input size");
+    }
+    buf = malloc(len ? (size_t)len : 1);
+    if (!buf) {
+        fclose(f);
+        die("out of memory");
+    }
+    if (fread(buf, 1, len, f) != (size_t)len) {
+        fclose(f);
+        free(buf);
+        die("could not read input");
+    }
+    fclose(f);
+    *plen = len;
+    return buf;
+}
+
+static void write_file(const char *filename, const uint8_t *buf, size_t len)
+{
+    FILE *f = fopen(filename, "wb");
+
+    if (!f)
+        die(strerror(errno));
+    if (fwrite(buf, 1, len, f) != len || fclose(f))
+        die("could not write output");
+}
+
+static uint8_t *find_unique(uint8_t *haystack, size_t haystack_len,
+                            const uint8_t *needle, size_t needle_len)
+{
+    uint8_t *match = NULL;
+    size_t i;
+
+    if (needle_len == 0 || needle_len > haystack_len)
+        die("invalid search sequence");
+    for(i = 0; i <= haystack_len - needle_len; i++) {
+        if (!memcmp(haystack + i, needle, needle_len)) {
+            if (match)
+                die("target sequence is not unique");
+            match = haystack + i;
+        }
+    }
+    if (!match)
+        die("target sequence was not found");
+    return match;
+}
+
+static uint8_t *find_previous_const_push(uint8_t *payload, uint8_t *pos)
+{
+    if (pos - payload >= 2 && pos[-2] == TEST_OP_push_const8)
+        return pos - 2;
+    if (pos - payload >= 5 && pos[-5] == TEST_OP_push_const)
+        return pos - 5;
+    return NULL;
+}
+
+static void mutate_function_opcode(uint8_t *payload, size_t payload_len)
+{
+    uint8_t *match = NULL;
+    size_t i;
+
+    for(i = 0; i < payload_len; i++) {
+        uint8_t *regexp_op, *bytecode_push, *pattern_push;
+
+        if (payload[i] != TEST_OP_regexp)
+            continue;
+        regexp_op = payload + i;
+        bytecode_push = find_previous_const_push(payload, regexp_op);
+        if (!bytecode_push)
+            continue;
+        pattern_push = find_previous_const_push(payload, bytecode_push);
+        if (!pattern_push)
+            continue;
+        if (match)
+            die("function regexp sequence is not unique");
+        match = regexp_op;
+    }
+    if (!match)
+        die("function regexp sequence was not found");
+    *match = TEST_OP_invalid;
+}
+
+static void mutate_regexp(uint8_t *payload, size_t payload_len,
+                          const char *pattern, const char *mode)
+{
+    uint8_t *compiled, *target;
+    uint8_t *metadata;
+    int compiled_len;
+    char error[128];
+
+    compiled = lre_compile(&compiled_len, error, sizeof(error), pattern,
+                           strlen(pattern), 0, NULL);
+    if (!compiled)
+        die(error);
+    target = find_unique(payload, payload_len, compiled, compiled_len);
+    metadata = target + 8 + get_u32(target + 4);
+    if (!strcmp(mode, "forge-atom")) {
+        put_u16(target, get_u16(target) | LRE_FLAG_ATOM);
+    } else if (!strcmp(mode, "clear-atom")) {
+        put_u16(target, get_u16(target) & ~LRE_FLAG_ATOM);
+    } else if (!strcmp(mode, "bad-regexp-opcode")) {
+        target[8] = 0xff;
+    } else if (!strcmp(mode, "bad-metadata-version")) {
+        metadata[LRE_META_VERSION_OFFSET]++;
+    } else if (!strcmp(mode, "bad-prefix-entry")) {
+        put_u32(metadata + LRE_META_ENTRY_OFFSET,
+                get_u32(metadata + LRE_META_ENTRY_OFFSET) + 1);
+    } else if (!strcmp(mode, "bad-quick-check")) {
+        put_u16(metadata + LRE_META_HEADER_LEN + LRE_QUICK_CHECK_MASK, 0);
+    } else {
+        free(compiled);
+        die("unknown regexp mutation");
+    }
+    free(compiled);
+}
+
+int main(int argc, char **argv)
+{
+    uint8_t *buf, *payload;
+    size_t len, payload_len;
+    const char *input, *output, *mode;
+
+    if (argc != 4) {
+        fprintf(stderr, "usage: %s input.qbc output.qbc mode\n", argv[0]);
+        return 1;
+    }
+    input = argv[1];
+    output = argv[2];
+    mode = argv[3];
+    buf = read_file(input, &len);
+    if (len < QBC_HEADER_SIZE || memcmp(buf, "QJSBC\0\r\n", 8))
+        die("invalid QBC header");
+    payload_len = get_u64(buf + QBC_PAYLOAD_SIZE_OFFSET);
+    if (payload_len != len - QBC_HEADER_SIZE)
+        die("invalid QBC payload size");
+    payload = buf + QBC_HEADER_SIZE;
+
+    if (!strcmp(mode, "forge-atom-capture")) {
+        mutate_regexp(payload, payload_len, "(abc)", "forge-atom");
+    } else if (!strcmp(mode, "forge-atom-nonliteral")) {
+        mutate_regexp(payload, payload_len, "a.c", "forge-atom");
+    } else if (!strcmp(mode, "clear-atom")) {
+        mutate_regexp(payload, payload_len, "abc", mode);
+    } else if (!strcmp(mode, "clear-atom-escaped")) {
+        mutate_regexp(payload, payload_len, "\\x74he quick brown fox",
+                      "clear-atom");
+    } else if (!strcmp(mode, "bad-regexp-opcode")) {
+        mutate_regexp(payload, payload_len, "abc", mode);
+    } else if (!strcmp(mode, "bad-metadata-version")) {
+        mutate_regexp(payload, payload_len, "abc", mode);
+    } else if (!strcmp(mode, "bad-prefix-entry")) {
+        mutate_regexp(payload, payload_len, "abcdef[0-9]+", mode);
+    } else if (!strcmp(mode, "bad-quick-check")) {
+        mutate_regexp(payload, payload_len, "[a-z]bcdef", mode);
+    } else if (!strcmp(mode, "bad-function-opcode")) {
+        mutate_function_opcode(payload, payload_len);
+    } else {
+        die("unknown mutation mode");
+    }
+
+    put_u64(buf + QBC_CHECKSUM_OFFSET, qbc_checksum(payload, payload_len));
+    write_file(output, buf, len);
+    free(buf);
+    return 0;
+}

--- a/tests/qbc_regexp_mutator.c
+++ b/tests/qbc_regexp_mutator.c
@@ -175,6 +175,14 @@ static void mutate_regexp(uint8_t *payload, size_t payload_len,
         target[8] = 0xff;
     } else if (!strcmp(mode, "bad-metadata-version")) {
         metadata[LRE_META_VERSION_OFFSET]++;
+    } else if (!strcmp(mode, "bad-source-payload")) {
+        metadata[LRE_META_FLAGS_OFFSET] |= LRE_META_FLAG_SOURCE;
+    } else if (!strcmp(mode, "bad-scan-entry")) {
+        put_u32(metadata + LRE_META_ENTRY_OFFSET,
+                get_u32(metadata + LRE_META_ENTRY_OFFSET) + 1);
+    } else if (!strcmp(mode, "bad-leading-char")) {
+        put_u32(metadata + LRE_META_HEADER_LEN,
+                get_u32(metadata + LRE_META_HEADER_LEN) + 1);
     } else if (!strcmp(mode, "bad-prefix-entry")) {
         put_u32(metadata + LRE_META_ENTRY_OFFSET,
                 get_u32(metadata + LRE_META_ENTRY_OFFSET) + 1);
@@ -208,6 +216,13 @@ int main(int argc, char **argv)
         die("invalid QBC payload size");
     payload = buf + QBC_HEADER_SIZE;
 
+    if (!strcmp(mode, "old-bytecode-version")) {
+        if (payload_len == 0)
+            die("bytecode payload is empty");
+        payload[0]--;
+        goto write_output;
+    }
+
     if (!strcmp(mode, "forge-atom-capture")) {
         mutate_regexp(payload, payload_len, "(abc)", "forge-atom");
     } else if (!strcmp(mode, "forge-atom-nonliteral")) {
@@ -221,6 +236,12 @@ int main(int argc, char **argv)
         mutate_regexp(payload, payload_len, "abc", mode);
     } else if (!strcmp(mode, "bad-metadata-version")) {
         mutate_regexp(payload, payload_len, "abc", mode);
+    } else if (!strcmp(mode, "bad-source-payload")) {
+        mutate_regexp(payload, payload_len, "\\x61bc", mode);
+    } else if (!strcmp(mode, "bad-scan-entry")) {
+        mutate_regexp(payload, payload_len, "a.c", mode);
+    } else if (!strcmp(mode, "bad-leading-char")) {
+        mutate_regexp(payload, payload_len, "(^|[^\\\\])\"x\"", mode);
     } else if (!strcmp(mode, "bad-prefix-entry")) {
         mutate_regexp(payload, payload_len, "abcdef[0-9]+", mode);
     } else if (!strcmp(mode, "bad-quick-check")) {
@@ -231,6 +252,7 @@ int main(int argc, char **argv)
         die("unknown mutation mode");
     }
 
+write_output:
     put_u64(buf + QBC_CHECKSUM_OFFSET, qbc_checksum(payload, payload_len));
     write_file(output, buf, len);
     free(buf);

--- a/tests/test_builtin.js
+++ b/tests/test_builtin.js
@@ -714,7 +714,7 @@ function test_date()
 
 function test_regexp()
 {
-    var a, str;
+    var a, str, re, calls, callback_args, seed, i, j, s, fast, generic;
     str = "abbbbbc";
     a = /(b+)c/.exec(str);
     assert(a[0], "bbbbbc");
@@ -788,6 +788,154 @@ function test_regexp()
     /* Note: SpiderMonkey and v8 may not be correct */
     assert("abcAbC".replace(/[\q{BC|A}]/gvi,"X"), "XXXX");
     assert("abcAbC".replace(/[\q{BC|A}--a]/gvi,"X"), "aXAX");
+
+    /* fast replacement and substitution semantics */
+    assert("abc abc".replace(/abc/g, "x"), "x x");
+    assert("abc abc".replace(/abc/g, ""), " ");
+    assert("abc".replace(/z/g, "x"), "abc");
+    assert("abc".replace(/(b)/, "<$1>"), "a<b>c");
+    assert("abc".replace(/b/, "$$"), "a$c");
+    assert("abc".replace(/b/, "[$&]"), "a[b]c");
+    assert("abc".replace(/b/, "[$`][$']"), "a[a][c]c");
+    assert("abc".replace(/b/, "$"), "a$c");
+    assert("abc".replace(/(?<letter>b)/, "<$<letter>>"), "a<b>c");
+
+    callback_args = undefined;
+    assert("abc".replace(/(b)/, function() {
+        callback_args = Array.prototype.slice.call(arguments);
+        return "X";
+    }), "aXc");
+    assert(callback_args, ["b", "b", 1, "abc"]);
+
+    re = /b/g;
+    calls = 0;
+    re.exec = function(str) {
+        calls++;
+        return RegExp.prototype.exec.call(this, str);
+    };
+    assert("abc".replace(re, "X"), "aXc");
+    assert(calls, 2);
+
+    /* raw literal atom candidates */
+    a = /quick/.exec("the quick brown fox");
+    assert(a[0], "quick");
+    assert(a.index, 4);
+    re = /quick/g;
+    assert(re.flags, "g");
+    assert(re.toString(), "/quick/g");
+    assert(/missing/.exec("the quick brown fox"), null);
+    a = /ᶠᵒˣ/.exec("the quick brown ᶠᵒˣ");
+    assert(a[0], "ᶠᵒˣ");
+    assert(a.index, 16);
+    a = /abc/.exec("\u0100abc");
+    assert(a[0], "abc");
+    assert(a.index, 1);
+    a = /ᶠ/.exec("xᶠ");
+    assert(a[0], "ᶠ");
+    assert(a.index, 1);
+    assert("abc abc".replace(/abc/g, "X"), "X X");
+
+    re = /abc/g;
+    re.lastIndex = 1;
+    a = re.exec("xabcabc");
+    assert(a.index, 1);
+    assert(re.lastIndex, 4);
+    a = re.exec("xabcabc");
+    assert(a.index, 4);
+    assert(re.lastIndex, 7);
+    assert(re.exec("xabcabc"), null);
+    assert(re.lastIndex, 0);
+
+    a = /abc/d.exec("zabc");
+    assert(a.indices[0], [1, 4]);
+    a = /(?:)/d.exec("abc");
+    assert(a[0], "");
+    assert(a.indices[0], [0, 0]);
+    a = /(a)(b)/d.exec("zab");
+    assert(a.indices, [[1, 3], [1, 2], [2, 3]]);
+
+    /* decoded literal metadata */
+    a = /\x61bc/d.exec("zabc");
+    assert(a[0], "abc");
+    assert(a.index, 1);
+    assert(a.indices[0], [1, 4]);
+    assert(/\u0061bc/.exec("zabc")[0], "abc");
+    assert(/a\.b/.exec("za.b")[0], "a.b");
+    assert(/\u1234x/.exec("z\u1234x")[0], "\u1234x");
+    assert(/\x61bc/.exec("\u0100abc").index, 1);
+    assert(/\u1234x/.exec("a\u1234x").index, 1);
+    assert(/\x61bc/.exec("missing"), null);
+    assert("abc abc".replace(/\x61bc/g, "X"), "X X");
+    assert("za.b".replace(/a\.b/, "[$&]"), "z[a.b]");
+
+    /* required-prefix candidate execution */
+    a = /abcdef[0-9]+/.exec("abcdefX---abcdef123");
+    assert(a[0], "abcdef123");
+    assert(a.index, 10);
+    assert(/abcdef[0-9]+/.exec("abcdefX"), null);
+    assert(/abcdef|abcxyz/.exec("zabcxyz")[0], "abcxyz");
+    a = /abc(def)?/.exec("zabcdef");
+    assert(a[0], "abcdef");
+    assert(a[1], "def");
+    assert("abcdef1 abcdef2".replace(/abcdef[0-9]+/g, "X"), "X X");
+    assert(/^abcdef[0-9]+/.exec("zabcdef1"), null);
+
+    /* multi-code-unit quick checks */
+    a = /[a-z]bcdef/.exec("000000xbcdef");
+    assert(a[0], "xbcdef");
+    assert(a.index, 6);
+    assert(/[a-z]bcdef/.exec("000000xbcdeg"), null);
+    assert(/[a-z]bcdef/.exec("0000000"), null);
+    assert("xbcdef ybcdef".replace(/[a-z]bcdef/g, "X"), "X X");
+
+    seed = 0x12345678;
+    for (i = 0; i < 200; i++) {
+        s = "";
+        for (j = 0; j < 40; j++) {
+            seed = (seed * 1103515245 + 12345) | 0;
+            s += "abcde0123456789X"[(seed >>> 16) % 16];
+        }
+        if ((i % 4) == 0)
+            s = s.slice(0, 7) + "abcdefX---abcdef123" + s.slice(26);
+        else if ((i % 4) == 1)
+            s = s.slice(0, 19) + "xbcdef" + s.slice(25);
+
+        fast = /abcdef([0-9]+)/.exec(s);
+        generic = /(?=a)abcdef([0-9]+)/.exec(s);
+        assert(fast === null, generic === null);
+        if (fast) {
+            assert(fast[0], generic[0]);
+            assert(fast[1], generic[1]);
+            assert(fast.index, generic.index);
+        }
+
+        fast = /[a-z]bcdef/.exec(s);
+        generic = /(?=[a-z])[a-z]bcdef/.exec(s);
+        assert(fast === null, generic === null);
+        if (fast) {
+            assert(fast[0], generic[0]);
+            assert(fast.index, generic.index);
+        }
+    }
+
+    /* patterns excluded from literal metadata */
+    assert(/abc/i.exec("zABC").index, 1);
+    assert(/abc/u.exec("zabc").index, 1);
+    assert(/abc/v.exec("zabc").index, 1);
+    assert(/(abc)/.exec("zabc")[1], "abc");
+    assert(/a.c/.exec("za-c")[0], "a-c");
+
+    re = /abc/y;
+    re.lastIndex = 1;
+    assert(re.exec("xabc")[0], "abc");
+    assert(re.lastIndex, 4);
+    re.lastIndex = 0;
+    assert(re.exec("xabc"), null);
+    assert(re.lastIndex, 0);
+
+    assert("abcdefghi".replace(/(a)(b)(c)(d)(e)(f)(g)(h)(i)/,
+                               "$9$1"), "ia");
+    assert("abc".replace(/(a)(b)(c)/, "$3$2$1"), "cba");
 
     /* case where lastIndex points to the second element of a
        surrogate pair */

--- a/tests/test_builtin.js
+++ b/tests/test_builtin.js
@@ -715,6 +715,7 @@ function test_date()
 function test_regexp()
 {
     var a, str, re, calls, callback_args, seed, i, j, s, fast, generic;
+    var compile_cases, compile_case, other_re;
     str = "abbbbbc";
     a = /(b+)c/.exec(str);
     assert(a[0], "bbbbbc");
@@ -887,6 +888,98 @@ function test_regexp()
     assert(/[a-z]bcdef/.exec("000000xbcdeg"), null);
     assert(/[a-z]bcdef/.exec("0000000"), null);
     assert("xbcdef ybcdef".replace(/[a-z]bcdef/g, "X"), "X X");
+
+    /* RegExp.prototype.compile() must refresh bytecode-owned metadata. */
+    compile_cases = [
+        ["abcdef[0-9]+", "(a|b)+", undefined, "bbbb", ["bbbb", "b"], 0],
+        ["[a-z]bcdef", "abc", undefined, "zabc", ["abc"], 1],
+        ["abcdef[0-9]+", "uvwxyz[0-9]+", undefined,
+         "--uvwxyz42", ["uvwxyz42"], 2],
+        ["abc", "\\x78yz", undefined, "-xyz", ["xyz"], 1],
+        ["(a|b)+", "abcdef[0-9]+", undefined,
+         "-abcdef7", ["abcdef7"], 1],
+        ["(a|b)+", "[a-z]bcdef", undefined, "-xbcdef", ["xbcdef"], 1],
+        ["(a|b)+", "abc", undefined, "-abc", ["abc"], 1],
+    ];
+    for (i = 0; i < compile_cases.length; i++) {
+        compile_case = compile_cases[i];
+        re = new RegExp(compile_case[0]);
+        re.compile(compile_case[1], compile_case[2]);
+        a = re.exec(compile_case[3]);
+        assert(Array.prototype.slice.call(a), compile_case[4]);
+        assert(a.index, compile_case[5]);
+        assert(a.input, compile_case[3]);
+    }
+
+    re = new RegExp("abcdef[0-9]+");
+    other_re = new RegExp("[a-z]bcdef");
+    re.compile(other_re);
+    a = re.exec("-xbcdef");
+    assert(Array.prototype.slice.call(a), ["xbcdef"]);
+    assert(a.index, 1);
+    re.compile(re);
+    assert(re.exec("-xbcdef")[0], "xbcdef");
+
+    re = new RegExp("abcdef[0-9]+");
+    re.lastIndex = 42;
+    re.compile("abc", "g");
+    assert(re.lastIndex, 0);
+    a = re.exec("-abcabc");
+    assert(a[0], "abc");
+    assert(a.index, 1);
+    assert(re.lastIndex, 4);
+    a = re.exec("-abcabc");
+    assert(a.index, 4);
+    assert(re.lastIndex, 7);
+    assert(re.exec("-abcabc"), null);
+    assert(re.lastIndex, 0);
+
+    re = new RegExp("abcdef[0-9]+");
+    re.compile("abc", "y");
+    re.lastIndex = 1;
+    assert(re.exec("-abc")[0], "abc");
+    assert(re.lastIndex, 4);
+    re.lastIndex = 0;
+    assert(re.exec("-abc"), null);
+    assert(re.lastIndex, 0);
+
+    re = new RegExp("abcdef[0-9]+");
+    re.compile("abc", "i");
+    assert(re.exec("-ABC")[0], "ABC");
+    re.compile("abc", "u");
+    assert(re.exec("-abc")[0], "abc");
+    re.compile("abc", "v");
+    assert(re.exec("-abc")[0], "abc");
+    re.compile("abc", "d");
+    a = re.exec("-abc");
+    assert(a[0], "abc");
+    assert(a.indices[0], [1, 4]);
+
+    re = new RegExp("abcdef[0-9]+");
+    re.compile("abc", "g");
+    assert("abc abc".replace(re, "X"), "X X");
+    re.compile("(a|b)+");
+    assert("--abba--".replace(re, "<$1>"), "--<a>--");
+    re.compile("abc");
+    assert(re.test("-abc"), true);
+
+    re = new RegExp("abcdef[0-9]+");
+    assert_throws(SyntaxError, function() { re.compile("abc", "gg"); });
+    assert(re.exec("-abcdef7")[0], "abcdef7");
+
+    re = new RegExp("abcdef[0-9]+");
+    Object.defineProperty(re, "lastIndex", { writable: false });
+    assert_throws(TypeError, function() { re.compile("(a|b)+"); });
+    assert(re.exec("bbbb")[0], "bbbb");
+
+    re = new RegExp("abcdef[0-9]+");
+    for (i = 0; i < 1000; i++) {
+        re.compile((i & 1) ? "abcdef[0-9]+" : "(a|b)+");
+        if ((i & 63) == 0 && typeof std !== "undefined")
+            std.gc();
+    }
+    re.compile("(a|b)+");
+    assert(re.exec("bbbb")[0], "bbbb");
 
     /* generic candidate scanning outside the backtracking stack */
     a = /(a|ab)c/.exec("xxabc");

--- a/tests/test_builtin.js
+++ b/tests/test_builtin.js
@@ -888,6 +888,55 @@ function test_regexp()
     assert(/[a-z]bcdef/.exec("0000000"), null);
     assert("xbcdef ybcdef".replace(/[a-z]bcdef/g, "X"), "X X");
 
+    /* generic candidate scanning outside the backtracking stack */
+    a = /(a|ab)c/.exec("xxabc");
+    assert(a[0], "abc");
+    assert(a[1], "ab");
+    assert(a.index, 2);
+    a = /(a)?b/.exec("aaab");
+    assert(a[0], "ab");
+    assert(a[1], "a");
+    assert(a.index, 2);
+    assert(/(?=(ab))ab/.exec("xxab"), ["ab", "ab"]);
+    assert(/(?<=a)b/.exec("zzab").index, 3);
+    assert(/$/.exec("abc").index, 3);
+    assert(/^b/m.exec("a\nb").index, 2);
+    assert(/\u{1f431}/u.exec("x🐱").index, 1);
+    assert("ab12 cd34".replace(/([a-z]+)([0-9]+)/g, "$2:$1"),
+           "12:ab 34:cd");
+
+    /* bounded leading alternation candidate filtering */
+    a = /(^|[^\\])"x"/.exec('00"x"');
+    assert(a[0], '0"x"');
+    assert(a[1], "0");
+    assert(a.index, 1);
+    assert(/(^|[^\\])"x"/.exec('\\"x"'), null);
+    a = /(^|[^\\])"x"/.exec('"x"');
+    assert(a[0], '"x"');
+    assert(a.index, 0);
+    a = /(^|[^\\])"x"/.exec('Ω"x"');
+    assert(a[0], 'Ω"x"');
+    assert(a.index, 0);
+    assert('00"x" \\"x"'.replace(/(^|[^\\])"x"/g, "X"),
+           "0X \\\"x\"");
+    assert(/(^|[^\\])"x"/m.exec('\n"x"').index, 0);
+    a = /(?:^|.)abcd/.exec("abcXzabcd");
+    assert(a[0], "zabcd");
+    assert(a.index, 4);
+    assert(/(^|x)abc/.exec("00xabc").index, 2);
+    assert(/(^|\s)abc/.exec("00 abc").index, 2);
+    assert(/(^|x)abc/i.exec("00XABC").index, 2);
+    re = /(^|x)abc/y;
+    re.lastIndex = 2;
+    assert(re.exec("00xabc")[0], "xabc");
+
+    re = /(a|ab)c/y;
+    re.lastIndex = 2;
+    a = re.exec("xxabc");
+    assert(a[0], "abc");
+    assert(a[1], "ab");
+    assert(re.lastIndex, 5);
+
     seed = 0x12345678;
     for (i = 0; i < 200; i++) {
         s = "";

--- a/tests/test_bytecode_file.sh
+++ b/tests/test_bytecode_file.sh
@@ -3,6 +3,7 @@ set -eu
 
 QJS="${QJS:-./qjs}"
 QJSC="${QJSC:-./qjsc}"
+QBC_REGEXP_MUTATOR="${QBC_REGEXP_MUTATOR:-./tests/qbc_regexp_mutator}"
 TMP_DIR="${TMPDIR:-/tmp}/quickjs-bytecode-file-test-$$"
 
 cleanup() {
@@ -78,3 +79,65 @@ if ! grep -q 'checksum mismatch' "$TMP_DIR/bad-checksum.err"; then
     cat "$TMP_DIR/bad-checksum.err" >&2
     exit 1
 fi
+
+cat > "$TMP_DIR/regexp-validation.js" <<'EOF'
+var results = [
+    /abc/.exec("zabc")[0],
+    /(abc)/.exec("zabc")[1],
+    /a.c/.exec("za-c")[0],
+    /abcdef[0-9]+/.exec("zabcdef1")[0],
+    /[a-z]bcdef/.exec("zxbcdef")[0],
+];
+console.log(results.join(","));
+console.log("regexp qbc validation sentinel");
+EOF
+
+"$QJSC" -s --bytecode -o "$TMP_DIR/regexp-validation.qbc" \
+    "$TMP_DIR/regexp-validation.js"
+cat > "$TMP_DIR/regexp-function-validation.js" <<'EOF'
+console.log(/abc/.test("abc"));
+EOF
+"$QJSC" -s --bytecode -o "$TMP_DIR/regexp-function-validation.qbc" \
+    "$TMP_DIR/regexp-function-validation.js"
+
+"$QBC_REGEXP_MUTATOR" "$TMP_DIR/regexp-validation.qbc" \
+    "$TMP_DIR/regexp-clear-atom.qbc" clear-atom
+"$QJS" --bytecode "$TMP_DIR/regexp-clear-atom.qbc" \
+    > "$TMP_DIR/regexp-clear-atom.out"
+if ! grep -q '^abc,abc,a-c,abcdef1,xbcdef$' "$TMP_DIR/regexp-clear-atom.out"; then
+    echo "qjs rejected or misexecuted a safe missing ATOM marker" >&2
+    cat "$TMP_DIR/regexp-clear-atom.out" >&2
+    exit 1
+fi
+
+for mode in forge-atom-capture forge-atom-nonliteral bad-regexp-opcode \
+    bad-metadata-version bad-prefix-entry bad-quick-check \
+    bad-function-opcode; do
+    mutation_input="$TMP_DIR/regexp-validation.qbc"
+    if [ "$mode" = bad-function-opcode ]; then
+        mutation_input="$TMP_DIR/regexp-function-validation.qbc"
+    fi
+    "$QBC_REGEXP_MUTATOR" "$mutation_input" \
+        "$TMP_DIR/$mode.qbc" "$mode"
+    status=0
+    "$QJS" --bytecode "$TMP_DIR/$mode.qbc" \
+        > "$TMP_DIR/$mode.out" 2> "$TMP_DIR/$mode.err" || status=$?
+    if [ "$status" -eq 0 ]; then
+        echo "qjs accepted malformed bytecode mode: $mode" >&2
+        exit 1
+    fi
+    if [ "$status" -ge 128 ]; then
+        echo "qjs crashed on malformed bytecode mode: $mode" >&2
+        cat "$TMP_DIR/$mode.err" >&2
+        exit 1
+    fi
+    if grep -q 'regexp qbc validation sentinel' "$TMP_DIR/$mode.out"; then
+        echo "qjs evaluated malformed bytecode mode: $mode" >&2
+        exit 1
+    fi
+    if ! grep -Eq 'invalid (regexp|function)' "$TMP_DIR/$mode.err"; then
+        echo "missing validation diagnostic for mode: $mode" >&2
+        cat "$TMP_DIR/$mode.err" >&2
+        exit 1
+    fi
+done

--- a/tests/test_bytecode_file.sh
+++ b/tests/test_bytecode_file.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+set -eu
+
+QJS="${QJS:-./qjs}"
+QJSC="${QJSC:-./qjsc}"
+TMP_DIR="${TMPDIR:-/tmp}/quickjs-bytecode-file-test-$$"
+
+cleanup() {
+    rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT INT TERM
+
+mkdir -p "$TMP_DIR"
+
+cat > "$TMP_DIR/hello.js" <<'EOF'
+var name = scriptArgs[1] || "world";
+console.log("hello " + name);
+EOF
+
+"$QJSC" --bytecode -o "$TMP_DIR/hello.qbc" "$TMP_DIR/hello.js"
+
+if [ ! -s "$TMP_DIR/hello.qbc" ]; then
+    echo "bytecode file was not created" >&2
+    exit 1
+fi
+
+"$QJS" --bytecode "$TMP_DIR/hello.qbc" QuickJS > "$TMP_DIR/out.txt"
+if ! grep -q '^hello QuickJS$' "$TMP_DIR/out.txt"; then
+    echo "bytecode execution produced unexpected output" >&2
+    cat "$TMP_DIR/out.txt" >&2
+    exit 1
+fi
+
+cat > "$TMP_DIR/module.mjs" <<'EOF'
+await 0;
+console.log("module bytecode ok");
+EOF
+
+"$QJSC" --bytecode -m -o "$TMP_DIR/module.qbc" "$TMP_DIR/module.mjs"
+"$QJS" --bytecode "$TMP_DIR/module.qbc" > "$TMP_DIR/module.out"
+if ! grep -q '^module bytecode ok$' "$TMP_DIR/module.out"; then
+    echo "module bytecode execution produced unexpected output" >&2
+    cat "$TMP_DIR/module.out" >&2
+    exit 1
+fi
+
+dd if=/dev/zero of="$TMP_DIR/not-bytecode.qbc" bs=1 count=64 2>/dev/null
+if "$QJS" --bytecode "$TMP_DIR/not-bytecode.qbc" > "$TMP_DIR/not-bytecode.out" 2> "$TMP_DIR/not-bytecode.err"; then
+    echo "qjs accepted a non-bytecode file" >&2
+    exit 1
+fi
+if ! grep -q 'bad magic' "$TMP_DIR/not-bytecode.err"; then
+    echo "missing bad magic diagnostic" >&2
+    cat "$TMP_DIR/not-bytecode.err" >&2
+    exit 1
+fi
+
+cp "$TMP_DIR/hello.qbc" "$TMP_DIR/bad-version.qbc"
+printf '0' | dd of="$TMP_DIR/bad-version.qbc" bs=1 seek=12 count=1 conv=notrunc 2>/dev/null
+if "$QJS" --bytecode "$TMP_DIR/bad-version.qbc" > "$TMP_DIR/bad-version.out" 2> "$TMP_DIR/bad-version.err"; then
+    echo "qjs accepted a bytecode file with a corrupted version" >&2
+    exit 1
+fi
+if ! grep -q 'version mismatch' "$TMP_DIR/bad-version.err"; then
+    echo "missing version mismatch diagnostic" >&2
+    cat "$TMP_DIR/bad-version.err" >&2
+    exit 1
+fi
+
+cp "$TMP_DIR/hello.qbc" "$TMP_DIR/bad-checksum.qbc"
+dd if=/dev/zero of="$TMP_DIR/bad-checksum.qbc" bs=1 seek=52 count=8 conv=notrunc 2>/dev/null
+if "$QJS" --bytecode "$TMP_DIR/bad-checksum.qbc" > "$TMP_DIR/bad-checksum.out" 2> "$TMP_DIR/bad-checksum.err"; then
+    echo "qjs accepted a bytecode file with a corrupted payload" >&2
+    exit 1
+fi
+if ! grep -q 'checksum mismatch' "$TMP_DIR/bad-checksum.err"; then
+    echo "missing checksum mismatch diagnostic" >&2
+    cat "$TMP_DIR/bad-checksum.err" >&2
+    exit 1
+fi

--- a/tests/test_bytecode_file.sh
+++ b/tests/test_bytecode_file.sh
@@ -83,10 +83,12 @@ fi
 cat > "$TMP_DIR/regexp-validation.js" <<'EOF'
 var results = [
     /abc/.exec("zabc")[0],
+    /\x61bc/.exec("zabc")[0],
     /(abc)/.exec("zabc")[1],
     /a.c/.exec("za-c")[0],
     /abcdef[0-9]+/.exec("zabcdef1")[0],
     /[a-z]bcdef/.exec("zxbcdef")[0],
+    /(^|[^\\])"x"/.exec('00"x"')[0],
 ];
 console.log(results.join(","));
 console.log("regexp qbc validation sentinel");
@@ -104,15 +106,15 @@ EOF
     "$TMP_DIR/regexp-clear-atom.qbc" clear-atom
 "$QJS" --bytecode "$TMP_DIR/regexp-clear-atom.qbc" \
     > "$TMP_DIR/regexp-clear-atom.out"
-if ! grep -q '^abc,abc,a-c,abcdef1,xbcdef$' "$TMP_DIR/regexp-clear-atom.out"; then
+if ! grep -q '^abc,abc,abc,a-c,abcdef1,xbcdef,0"x"$' "$TMP_DIR/regexp-clear-atom.out"; then
     echo "qjs rejected or misexecuted a safe missing ATOM marker" >&2
     cat "$TMP_DIR/regexp-clear-atom.out" >&2
     exit 1
 fi
 
 for mode in forge-atom-capture forge-atom-nonliteral bad-regexp-opcode \
-    bad-metadata-version bad-prefix-entry bad-quick-check \
-    bad-function-opcode; do
+    bad-metadata-version bad-source-payload bad-scan-entry \
+    bad-leading-char bad-prefix-entry bad-quick-check bad-function-opcode; do
     mutation_input="$TMP_DIR/regexp-validation.qbc"
     if [ "$mode" = bad-function-opcode ]; then
         mutation_input="$TMP_DIR/regexp-function-validation.qbc"
@@ -141,3 +143,17 @@ for mode in forge-atom-capture forge-atom-nonliteral bad-regexp-opcode \
         exit 1
     fi
 done
+
+"$QBC_REGEXP_MUTATOR" "$TMP_DIR/regexp-validation.qbc" \
+    "$TMP_DIR/old-bytecode-version.qbc" old-bytecode-version
+if "$QJS" --bytecode "$TMP_DIR/old-bytecode-version.qbc" \
+    > "$TMP_DIR/old-bytecode-version.out" \
+    2> "$TMP_DIR/old-bytecode-version.err"; then
+    echo "qjs accepted a prior bytecode version" >&2
+    exit 1
+fi
+if ! grep -q 'invalid version' "$TMP_DIR/old-bytecode-version.err"; then
+    echo "missing prior bytecode version diagnostic" >&2
+    cat "$TMP_DIR/old-bytecode-version.err" >&2
+    exit 1
+fi

--- a/tests/test_regexp_bytecode.c
+++ b/tests/test_regexp_bytecode.c
@@ -1,0 +1,468 @@
+/*
+ * RegExp bytecode validator tests
+ *
+ * Copyright (c) 2026 QuickJS contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "cutils.h"
+#include "libregexp.h"
+
+typedef enum {
+#define DEF(id, size) TEST_REOP_ ## id,
+#include "libregexp-opcode.h"
+#undef DEF
+    TEST_REOP_COUNT,
+} TestREOpcode;
+
+#define TEST_RE_HEADER_FLAGS 0
+#define TEST_RE_HEADER_CAPTURE_COUNT 2
+#define TEST_RE_HEADER_REGISTER_COUNT 3
+#define TEST_RE_HEADER_BYTECODE_LEN 4
+#define TEST_RE_HEADER_LEN 8
+#define TEST_RE_META_VERSION_OFFSET 0
+#define TEST_RE_META_KIND_OFFSET 1
+#define TEST_RE_META_ENCODING_OFFSET 2
+#define TEST_RE_META_FLAGS_OFFSET 3
+#define TEST_RE_META_PAYLOAD_SIZE_OFFSET 4
+#define TEST_RE_META_LENGTH_OFFSET 8
+#define TEST_RE_META_ENTRY_OFFSET 12
+#define TEST_RE_META_HEADER_LEN 16
+
+int lre_check_stack_overflow(void *opaque, size_t alloca_size)
+{
+    return 0;
+}
+
+int lre_check_timeout(void *opaque)
+{
+    return 0;
+}
+
+void *lre_realloc(void *opaque, void *ptr, size_t size)
+{
+    return realloc(ptr, size);
+}
+
+static uint8_t *compile_regexp(const char *pattern, int flags, int *plen)
+{
+    char error[128];
+    uint8_t *buf;
+
+    buf = lre_compile(plen, error, sizeof(error), pattern, strlen(pattern),
+                      flags, NULL);
+    if (!buf) {
+        fprintf(stderr, "compile failed for '%s': %s\n", pattern, error);
+        abort();
+    }
+    return buf;
+}
+
+static void expect_valid(const uint8_t *buf, size_t len)
+{
+    char error[128];
+
+    if (lre_validate_bytecode(buf, len, error, sizeof(error), NULL)) {
+        fprintf(stderr, "expected valid bytecode: %s\n", error);
+        abort();
+    }
+}
+
+static void expect_invalid(const uint8_t *buf, size_t len)
+{
+    static int test_index;
+    char error[128];
+
+    test_index++;
+    if (!lre_validate_bytecode(buf, len, error, sizeof(error), NULL)) {
+        fprintf(stderr, "expected invalid bytecode in case %d\n", test_index);
+        abort();
+    }
+    assert(error[0] != '\0');
+}
+
+static uint8_t *dup_bytecode(const uint8_t *buf, size_t len)
+{
+    uint8_t *copy = malloc(len);
+
+    assert(copy != NULL);
+    memcpy(copy, buf, len);
+    return copy;
+}
+
+static size_t find_opcode(const uint8_t *buf, size_t len, int wanted)
+{
+    size_t code_len = get_u32(buf + TEST_RE_HEADER_BYTECODE_LEN);
+    size_t pos = TEST_RE_HEADER_LEN;
+    size_t end = pos + code_len;
+    static const uint8_t sizes[TEST_REOP_COUNT] = {
+#define DEF(id, size) size,
+#include "libregexp-opcode.h"
+#undef DEF
+    };
+
+    assert(end <= len);
+    while (pos < end) {
+        int opcode = buf[pos];
+        size_t insn_len;
+
+        assert(opcode > TEST_REOP_invalid && opcode < TEST_REOP_COUNT);
+        if (opcode == wanted)
+            return pos;
+        insn_len = sizes[opcode];
+        if (opcode == TEST_REOP_range || opcode == TEST_REOP_range_i)
+            insn_len += get_u16(buf + pos + 1) * 4;
+        else if (opcode == TEST_REOP_range32 || opcode == TEST_REOP_range32_i)
+            insn_len += get_u16(buf + pos + 1) * 8;
+        else if (opcode == TEST_REOP_back_reference ||
+                 opcode == TEST_REOP_back_reference_i ||
+                 opcode == TEST_REOP_backward_back_reference ||
+                 opcode == TEST_REOP_backward_back_reference_i)
+            insn_len += buf[pos + 1];
+        pos += insn_len;
+    }
+    return SIZE_MAX;
+}
+
+static void test_valid_bytecode(void)
+{
+    static const struct {
+        const char *pattern;
+        int flags;
+    } cases[] = {
+        { "abc", 0 },
+        { "[a-z]+", LRE_FLAG_GLOBAL },
+        { "(?=abc)abc", 0 },
+        { "(ab)\\1", 0 },
+        { "(?<word>ab)+", LRE_FLAG_INDICES },
+        { "[^a-z]", LRE_FLAG_UNICODE },
+    };
+    size_t i;
+
+    for(i = 0; i < countof(cases); i++) {
+        uint8_t *buf;
+        int len;
+
+        buf = compile_regexp(cases[i].pattern, cases[i].flags, &len);
+        expect_valid(buf, len);
+        free(buf);
+    }
+}
+
+static void test_header_validation(void)
+{
+    uint8_t *buf, *copy;
+    int len;
+
+    buf = compile_regexp("abc", 0, &len);
+    expect_invalid(buf, TEST_RE_HEADER_LEN - 1);
+
+    copy = dup_bytecode(buf, len);
+    put_u16(copy + TEST_RE_HEADER_FLAGS,
+            get_u16(copy + TEST_RE_HEADER_FLAGS) | (1 << 15));
+    expect_invalid(copy, len);
+    free(copy);
+
+    copy = dup_bytecode(buf, len);
+    copy[TEST_RE_HEADER_CAPTURE_COUNT] = 0;
+    expect_invalid(copy, len);
+    free(copy);
+
+    copy = dup_bytecode(buf, len);
+    copy[TEST_RE_HEADER_CAPTURE_COUNT] = 2;
+    put_u16(copy + TEST_RE_HEADER_FLAGS,
+            get_u16(copy + TEST_RE_HEADER_FLAGS) | LRE_FLAG_ATOM);
+    expect_invalid(copy, len);
+    free(copy);
+
+    copy = dup_bytecode(buf, len);
+    put_u32(copy + TEST_RE_HEADER_BYTECODE_LEN, len);
+    expect_invalid(copy, len);
+    free(copy);
+    free(buf);
+}
+
+static void test_instruction_validation(void)
+{
+    uint8_t *buf, *copy;
+    size_t pos;
+    int len;
+
+    buf = compile_regexp("[a-z]+", 0, &len);
+    copy = dup_bytecode(buf, len);
+    copy[TEST_RE_HEADER_LEN] = 0xff;
+    expect_invalid(copy, len);
+    free(copy);
+
+    pos = find_opcode(buf, len, TEST_REOP_range);
+    assert(pos != SIZE_MAX);
+    copy = dup_bytecode(buf, len);
+    put_u16(copy + pos + 1, 0xffff);
+    expect_invalid(copy, len);
+    free(copy);
+
+    pos = find_opcode(buf, len, TEST_REOP_split_goto_first);
+    assert(pos != SIZE_MAX);
+    copy = dup_bytecode(buf, len);
+    put_u32(copy + pos + 1, 2);
+    expect_invalid(copy, len);
+    free(copy);
+
+    pos = find_opcode(buf, len, TEST_REOP_save_start);
+    assert(pos != SIZE_MAX);
+    copy = dup_bytecode(buf, len);
+    copy[pos + 1] = copy[TEST_RE_HEADER_CAPTURE_COUNT];
+    expect_invalid(copy, len);
+    free(copy);
+
+    copy = dup_bytecode(buf, len);
+    copy[TEST_RE_HEADER_REGISTER_COUNT]++;
+    expect_invalid(copy, len);
+    free(copy);
+    free(buf);
+}
+
+static void test_lookahead_and_group_validation(void)
+{
+    uint8_t *buf, *copy;
+    size_t pos;
+    int len;
+
+    buf = compile_regexp("(?=abc)abc", 0, &len);
+    pos = find_opcode(buf, len, TEST_REOP_lookahead);
+    assert(pos != SIZE_MAX);
+    copy = dup_bytecode(buf, len);
+    put_u32(copy + pos + 1, 0);
+    expect_invalid(copy, len);
+    free(copy);
+    free(buf);
+
+    buf = compile_regexp("(?<word>ab)", 0, &len);
+    expect_valid(buf, len);
+    expect_invalid(buf, len - 1);
+    copy = dup_bytecode(buf, len);
+    copy[len - 2] = 'x';
+    expect_invalid(copy, len);
+    free(copy);
+    free(buf);
+}
+
+static void test_literal_metadata(void)
+{
+    LREMetadata meta;
+    uint8_t *buf, *copy;
+    size_t meta_pos;
+    int len;
+
+    buf = compile_regexp("abc", 0, &len);
+    assert((lre_get_flags(buf) & (LRE_FLAG_ATOM | LRE_FLAG_HAS_META)) ==
+           (LRE_FLAG_ATOM | LRE_FLAG_HAS_META));
+    assert(lre_get_metadata(buf, len, &meta) == 1);
+    assert(meta.kind == LRE_META_LITERAL && meta.encoding == 0);
+    assert(meta.flags == LRE_META_FLAG_SOURCE);
+    assert(meta.length == 3 && meta.payload_size == 3);
+    assert(memcmp(meta.payload, "abc", 3) == 0);
+    free(buf);
+
+    buf = compile_regexp("\\x61bc", 0, &len);
+    expect_valid(buf, len);
+    assert(lre_get_metadata(buf, len, &meta) == 1);
+    assert(meta.kind == LRE_META_LITERAL && meta.encoding == 0);
+    assert(meta.flags == 0 && meta.length == 3);
+    assert(memcmp(meta.payload, "abc", 3) == 0);
+    meta_pos = TEST_RE_HEADER_LEN +
+        get_u32(buf + TEST_RE_HEADER_BYTECODE_LEN);
+
+    copy = dup_bytecode(buf, len);
+    copy[meta_pos + TEST_RE_META_VERSION_OFFSET]++;
+    expect_invalid(copy, len);
+    free(copy);
+
+    copy = dup_bytecode(buf, len);
+    copy[meta_pos + TEST_RE_META_KIND_OFFSET] = LRE_META_NONE;
+    expect_invalid(copy, len);
+    free(copy);
+
+    copy = dup_bytecode(buf, len);
+    copy[meta_pos + TEST_RE_META_ENCODING_OFFSET] = 2;
+    expect_invalid(copy, len);
+    free(copy);
+
+    copy = dup_bytecode(buf, len);
+    copy[meta_pos + TEST_RE_META_FLAGS_OFFSET] = 0x80;
+    expect_invalid(copy, len);
+    free(copy);
+
+    copy = dup_bytecode(buf, len);
+    put_u32(copy + meta_pos + TEST_RE_META_PAYLOAD_SIZE_OFFSET, len);
+    expect_invalid(copy, len);
+    free(copy);
+
+    copy = dup_bytecode(buf, len);
+    put_u32(copy + meta_pos + TEST_RE_META_LENGTH_OFFSET, 2);
+    expect_invalid(copy, len);
+    free(copy);
+
+    copy = dup_bytecode(buf, len);
+    copy[meta_pos + TEST_RE_META_HEADER_LEN] = 'z';
+    expect_invalid(copy, len);
+    free(copy);
+    free(buf);
+
+    buf = compile_regexp("\\u1234x", 0, &len);
+    expect_valid(buf, len);
+    assert(lre_get_metadata(buf, len, &meta) == 1);
+    assert(meta.encoding == 1 && meta.length == 2 && meta.payload_size == 4);
+    assert(get_u16(meta.payload) == 0x1234);
+    assert(get_u16(meta.payload + 2) == 'x');
+    free(buf);
+
+    buf = compile_regexp("a.c", 0, &len);
+    assert(!(lre_get_flags(buf) & LRE_FLAG_HAS_META));
+    assert(lre_get_metadata(buf, len, &meta) == 0);
+    free(buf);
+}
+
+static void test_prefix_metadata(void)
+{
+    LREMetadata meta;
+    uint8_t *buf, *copy;
+    uint8_t *capture[4];
+    size_t meta_pos;
+    int len;
+
+    buf = compile_regexp("abcdef[0-9]+", 0, &len);
+    expect_valid(buf, len);
+    assert(!(lre_get_flags(buf) & LRE_FLAG_ATOM));
+    assert(lre_get_metadata(buf, len, &meta) == 1);
+    assert(meta.kind == LRE_META_PREFIX && meta.encoding == 0);
+    assert(meta.flags == 0 && meta.length == 6);
+    assert(meta.entry_offset == 11);
+    assert(memcmp(meta.payload, "abcdef", 6) == 0);
+    assert(lre_exec_at(capture, buf, meta.entry_offset,
+                       (const uint8_t *)"zzzabcdef123", 3, 12, 0, NULL) == 1);
+
+    meta_pos = TEST_RE_HEADER_LEN +
+        get_u32(buf + TEST_RE_HEADER_BYTECODE_LEN);
+    copy = dup_bytecode(buf, len);
+    put_u32(copy + meta_pos + TEST_RE_META_ENTRY_OFFSET,
+            meta.entry_offset + 1);
+    expect_invalid(copy, len);
+    free(copy);
+
+    copy = dup_bytecode(buf, len);
+    copy[meta_pos + TEST_RE_META_HEADER_LEN] = 'z';
+    expect_invalid(copy, len);
+    free(copy);
+    free(buf);
+
+    buf = compile_regexp("abcdef|abcxyz", 0, &len);
+    expect_valid(buf, len);
+    assert(lre_get_metadata(buf, len, &meta) == 1);
+    assert(meta.kind == LRE_META_PREFIX && meta.length == 3);
+    assert(memcmp(meta.payload, "abc", 3) == 0);
+    free(buf);
+
+    buf = compile_regexp("^abcdef[0-9]+", 0, &len);
+    assert(lre_get_metadata(buf, len, &meta) == 0);
+    free(buf);
+
+    buf = compile_regexp("ab(c)?def", 0, &len);
+    assert(lre_get_metadata(buf, len, &meta) == 0);
+    free(buf);
+}
+
+static void test_quick_check_metadata(void)
+{
+    LREMetadata meta;
+    uint8_t *buf, *copy;
+    const uint8_t *record;
+    size_t meta_pos;
+    int len;
+
+    buf = compile_regexp("[a-z]bcdef", 0, &len);
+    expect_valid(buf, len);
+    assert(lre_get_metadata(buf, len, &meta) == 1);
+    assert(meta.kind == LRE_META_QUICK_CHECK && meta.length == 4);
+    assert(meta.entry_offset == 11);
+    assert(meta.payload_size == 4 * LRE_QUICK_CHECK_RECORD_SIZE);
+    record = meta.payload;
+    assert(get_u16(record + LRE_QUICK_CHECK_OFFSET) == 0);
+    assert(get_u16(record + LRE_QUICK_CHECK_MASK) != 0);
+    record += LRE_QUICK_CHECK_RECORD_SIZE;
+    assert(get_u16(record + LRE_QUICK_CHECK_OFFSET) == 1);
+    assert(get_u16(record + LRE_QUICK_CHECK_VALUE) == 'b');
+    assert(get_u16(record + LRE_QUICK_CHECK_MASK) == 0xffff);
+
+    meta_pos = TEST_RE_HEADER_LEN +
+        get_u32(buf + TEST_RE_HEADER_BYTECODE_LEN);
+    copy = dup_bytecode(buf, len);
+    put_u16(copy + meta_pos + TEST_RE_META_HEADER_LEN +
+            LRE_QUICK_CHECK_MASK, 0);
+    expect_invalid(copy, len);
+    free(copy);
+
+    copy = dup_bytecode(buf, len);
+    put_u16(copy + meta_pos + TEST_RE_META_HEADER_LEN +
+            LRE_QUICK_CHECK_VALUE, 0xffff);
+    expect_invalid(copy, len);
+    free(copy);
+    free(buf);
+
+    buf = compile_regexp("[a-z]b", 0, &len);
+    assert(lre_get_metadata(buf, len, &meta) == 0);
+    free(buf);
+}
+
+static void test_arbitrary_bytecode(void)
+{
+    uint8_t buf[96];
+    uint32_t state = 0x31415926;
+    size_t i, j, len;
+    char error[128];
+
+    for(i = 0; i < 10000; i++) {
+        state = state * 1664525 + 1013904223;
+        len = state % (sizeof(buf) + 1);
+        for(j = 0; j < len; j++) {
+            state = state * 1664525 + 1013904223;
+            buf[j] = state >> 24;
+        }
+        lre_validate_bytecode(buf, len, error, sizeof(error), NULL);
+    }
+}
+
+int main(void)
+{
+    test_valid_bytecode();
+    test_header_validation();
+    test_instruction_validation();
+    test_lookahead_and_group_validation();
+    test_literal_metadata();
+    test_prefix_metadata();
+    test_quick_check_metadata();
+    test_arbitrary_bytecode();
+    return 0;
+}

--- a/tests/test_regexp_bytecode.c
+++ b/tests/test_regexp_bytecode.c
@@ -49,7 +49,9 @@ typedef enum {
 #define TEST_RE_META_PAYLOAD_SIZE_OFFSET 4
 #define TEST_RE_META_LENGTH_OFFSET 8
 #define TEST_RE_META_ENTRY_OFFSET 12
-#define TEST_RE_META_HEADER_LEN 16
+#define TEST_RE_META_EXEC_FLAGS_OFFSET 16
+#define TEST_RE_META_LEADING_COUNT_OFFSET 20
+#define TEST_RE_META_HEADER_LEN 24
 
 int lre_check_stack_overflow(void *opaque, size_t alloca_size)
 {
@@ -282,8 +284,14 @@ static void test_literal_metadata(void)
     assert(lre_get_metadata(buf, len, &meta) == 1);
     assert(meta.kind == LRE_META_LITERAL && meta.encoding == 0);
     assert(meta.flags == LRE_META_FLAG_SOURCE);
-    assert(meta.length == 3 && meta.payload_size == 3);
-    assert(memcmp(meta.payload, "abc", 3) == 0);
+    assert(meta.length == 3 && meta.payload_size == 0);
+    meta_pos = TEST_RE_HEADER_LEN +
+        get_u32(buf + TEST_RE_HEADER_BYTECODE_LEN);
+    copy = dup_bytecode(buf, len);
+    put_u32(copy + meta_pos + TEST_RE_META_PAYLOAD_SIZE_OFFSET, 1);
+    expect_invalid(copy, len);
+    free(copy);
+    expect_invalid(buf, meta_pos + TEST_RE_META_HEADER_LEN - 1);
     free(buf);
 
     buf = compile_regexp("\\x61bc", 0, &len);
@@ -329,6 +337,7 @@ static void test_literal_metadata(void)
     copy[meta_pos + TEST_RE_META_HEADER_LEN] = 'z';
     expect_invalid(copy, len);
     free(copy);
+    expect_invalid(buf, len - 1);
     free(buf);
 
     buf = compile_regexp("\\u1234x", 0, &len);
@@ -340,6 +349,14 @@ static void test_literal_metadata(void)
     free(buf);
 
     buf = compile_regexp("a.c", 0, &len);
+    assert(lre_get_flags(buf) & LRE_FLAG_HAS_META);
+    assert(lre_get_metadata(buf, len, &meta) == 1);
+    assert(meta.kind == LRE_META_NONE && meta.length == 0);
+    assert(meta.exec_flags == LRE_META_EXEC_SCAN);
+    assert(meta.leading_count == 0 && meta.payload_size == 0);
+    free(buf);
+
+    buf = compile_regexp("a.c", LRE_FLAG_STICKY, &len);
     assert(!(lre_get_flags(buf) & LRE_FLAG_HAS_META));
     assert(lre_get_metadata(buf, len, &meta) == 0);
     free(buf);
@@ -385,12 +402,51 @@ static void test_prefix_metadata(void)
     assert(memcmp(meta.payload, "abc", 3) == 0);
     free(buf);
 
+    buf = compile_regexp("abcdefghijklmnopqrstuvwxyzABCDEF[0-9]+", 0,
+                         &len);
+    expect_valid(buf, len);
+    assert(lre_get_metadata(buf, len, &meta) == 1);
+    assert(meta.kind == LRE_META_PREFIX &&
+           meta.length == LRE_PREFIX_MAX_LENGTH);
+    assert(meta.payload_size == LRE_PREFIX_MAX_LENGTH);
+    assert(memcmp(meta.payload, "abcdefghijklmnopqrstuvwxyzABCDEF",
+                  LRE_PREFIX_MAX_LENGTH) == 0);
+    free(buf);
+
+    buf = compile_regexp("abcdefghijklmnopqrstuvwxyzABCDEFG[0-9]+", 0,
+                         &len);
+    expect_valid(buf, len);
+    assert(lre_get_metadata(buf, len, &meta) == 1);
+    assert(meta.kind == LRE_META_PREFIX &&
+           meta.length == LRE_PREFIX_MAX_LENGTH);
+    assert(memcmp(meta.payload, "abcdefghijklmnopqrstuvwxyzABCDEF",
+                  LRE_PREFIX_MAX_LENGTH) == 0);
+    meta_pos = TEST_RE_HEADER_LEN +
+        get_u32(buf + TEST_RE_HEADER_BYTECODE_LEN);
+    copy = dup_bytecode(buf, len);
+    put_u32(copy + meta_pos + TEST_RE_META_LENGTH_OFFSET,
+            LRE_PREFIX_MAX_LENGTH + 1);
+    expect_invalid(copy, len);
+    free(copy);
+    free(buf);
+
+    buf = compile_regexp("abcdef(?<word>[0-9]+)", 0, &len);
+    expect_valid(buf, len);
+    assert(lre_get_metadata(buf, len, &meta) == 1);
+    assert(meta.kind == LRE_META_PREFIX && meta.length == 6);
+    assert(lre_get_groupnames(buf, len) != NULL);
+    free(buf);
+
     buf = compile_regexp("^abcdef[0-9]+", 0, &len);
-    assert(lre_get_metadata(buf, len, &meta) == 0);
+    assert(lre_get_metadata(buf, len, &meta) == 1);
+    assert(meta.kind == LRE_META_NONE &&
+           meta.exec_flags == LRE_META_EXEC_SCAN);
     free(buf);
 
     buf = compile_regexp("ab(c)?def", 0, &len);
-    assert(lre_get_metadata(buf, len, &meta) == 0);
+    assert(lre_get_metadata(buf, len, &meta) == 1);
+    assert(meta.kind == LRE_META_NONE &&
+           meta.exec_flags == LRE_META_EXEC_SCAN);
     free(buf);
 }
 
@@ -432,8 +488,112 @@ static void test_quick_check_metadata(void)
     free(buf);
 
     buf = compile_regexp("[a-z]b", 0, &len);
-    assert(lre_get_metadata(buf, len, &meta) == 0);
+    assert(lre_get_metadata(buf, len, &meta) == 1);
+    assert(meta.kind == LRE_META_NONE &&
+           meta.exec_flags == LRE_META_EXEC_SCAN);
     free(buf);
+}
+
+static void test_execution_descriptor(void)
+{
+    LREMetadata meta;
+    uint8_t *buf, *copy;
+    size_t meta_pos;
+    int len;
+
+    buf = compile_regexp("(^|[^\\\\])\"x\"", 0, &len);
+    expect_valid(buf, len);
+    assert(lre_get_metadata(buf, len, &meta) == 1);
+    assert(meta.kind == LRE_META_NONE);
+    assert(meta.exec_flags ==
+           (LRE_META_EXEC_SCAN | LRE_META_EXEC_LEADING));
+    assert(meta.entry_offset == 11 && meta.leading_count == 3);
+    assert(get_u32(meta.leading_chars) == '"');
+    assert(get_u32(meta.leading_chars + 4) == 'x');
+    assert(get_u32(meta.leading_chars + 8) == '"');
+
+    meta_pos = TEST_RE_HEADER_LEN +
+        get_u32(buf + TEST_RE_HEADER_BYTECODE_LEN);
+    copy = dup_bytecode(buf, len);
+    put_u32(copy + meta_pos + TEST_RE_META_EXEC_FLAGS_OFFSET,
+            LRE_META_EXEC_LEADING);
+    expect_invalid(copy, len);
+    free(copy);
+
+    copy = dup_bytecode(buf, len);
+    put_u32(copy + meta_pos + TEST_RE_META_LEADING_COUNT_OFFSET,
+            LRE_META_LEADING_MAX + 1);
+    expect_invalid(copy, len);
+    free(copy);
+
+    copy = dup_bytecode(buf, len);
+    put_u32(copy + meta_pos + TEST_RE_META_HEADER_LEN, 'z');
+    expect_invalid(copy, len);
+    free(copy);
+    free(buf);
+}
+
+static void test_descriptor_generic_differential(void)
+{
+    static const char * const patterns[] = {
+        "a.c",
+        "(^|[^\\\\])\"x\"",
+        "(a|ab)+c",
+        "(?=(ab+))ab+c",
+        "[a-z]bcdef",
+        "abcdef[0-9]+",
+    };
+    uint32_t state = 0x5eed1234;
+    char subject[65];
+    size_t case_index, i, j;
+
+    for(case_index = 0; case_index < countof(patterns); case_index++) {
+        uint8_t *buf, *generic;
+        uint8_t **capture, **generic_capture;
+        int alloc_count, capture_count, len;
+
+        buf = compile_regexp(patterns[case_index], 0, &len);
+        generic = dup_bytecode(buf, len);
+        put_u16(generic + TEST_RE_HEADER_FLAGS,
+                get_u16(generic + TEST_RE_HEADER_FLAGS) &
+                ~(LRE_FLAG_HAS_META | LRE_FLAG_ATOM));
+        capture_count = lre_get_capture_count(buf);
+        alloc_count = lre_get_alloc_count(buf);
+        capture = calloc(alloc_count, sizeof(*capture));
+        generic_capture = calloc(alloc_count,
+                                 sizeof(*generic_capture));
+        assert(capture != NULL && generic_capture != NULL);
+
+        for(i = 0; i < 200; i++) {
+            int ret, generic_ret;
+
+            for(j = 0; j < sizeof(subject) - 1; j++) {
+                state = state * 1664525 + 1013904223;
+                subject[j] = "abcxyz0\\\""[state % 9];
+            }
+            subject[sizeof(subject) - 1] = '\0';
+            ret = lre_exec(capture, buf, (const uint8_t *)subject, 0,
+                           sizeof(subject) - 1, 0, NULL);
+            generic_ret = lre_exec(generic_capture, generic,
+                                   (const uint8_t *)subject, 0,
+                                   sizeof(subject) - 1, 0, NULL);
+            assert(ret == generic_ret);
+            if (ret == 1) {
+                for(j = 0; j < (size_t)capture_count * 2; j++) {
+                    if (capture[j] == NULL || generic_capture[j] == NULL) {
+                        assert(capture[j] == generic_capture[j]);
+                    } else {
+                        assert(capture[j] - (uint8_t *)subject ==
+                               generic_capture[j] - (uint8_t *)subject);
+                    }
+                }
+            }
+        }
+        free(generic_capture);
+        free(capture);
+        free(generic);
+        free(buf);
+    }
 }
 
 static void test_arbitrary_bytecode(void)
@@ -463,6 +623,8 @@ int main(void)
     test_literal_metadata();
     test_prefix_metadata();
     test_quick_check_metadata();
+    test_execution_descriptor();
+    test_descriptor_generic_differential();
     test_arbitrary_bytecode();
     return 0;
 }

--- a/tests/test_regexp_interrupt.c
+++ b/tests/test_regexp_interrupt.c
@@ -1,0 +1,112 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "quickjs.h"
+
+typedef struct InterruptState {
+    int calls;
+    int stop;
+} InterruptState;
+
+static void fail(const char *message)
+{
+    fprintf(stderr, "test_regexp_interrupt: %s\n", message);
+    exit(1);
+}
+
+static int interrupt_handler(JSRuntime *rt, void *opaque)
+{
+    InterruptState *state = opaque;
+
+    state->calls++;
+    return state->stop;
+}
+
+static JSValue eval(JSContext *ctx, const char *source)
+{
+    return JS_Eval(ctx, source, strlen(source), "<regexp-interrupt>",
+                   JS_EVAL_TYPE_GLOBAL);
+}
+
+static void eval_setup(JSContext *ctx, const char *source)
+{
+    JSValue value = eval(ctx, source);
+
+    if (JS_IsException(value))
+        fail("setup evaluation failed");
+    JS_FreeValue(ctx, value);
+}
+
+static void run_case(JSRuntime *rt, JSContext *ctx, const char *expression,
+                     int stop, int expect_calls)
+{
+    InterruptState state = { 0, stop };
+    JSValue value;
+    int result;
+
+    JS_SetInterruptHandler(rt, interrupt_handler, &state);
+    value = eval(ctx, expression);
+    JS_SetInterruptHandler(rt, NULL, NULL);
+
+    if (stop) {
+        JSValue exception;
+
+        if (!JS_IsException(value)) {
+            JS_FreeValue(ctx, value);
+            fail("regexp scan ignored an interrupt request");
+        }
+        exception = JS_GetException(ctx);
+        JS_FreeValue(ctx, exception);
+    } else {
+        if (JS_IsException(value))
+            fail("regexp scan failed while interrupt handler continued");
+        result = JS_ToBool(ctx, value);
+        JS_FreeValue(ctx, value);
+        if (result != 1)
+            fail("regexp scan returned an unexpected result");
+    }
+    if (expect_calls && state.calls == 0)
+        fail("regexp scan did not poll the interrupt handler");
+    if (!expect_calls && state.calls != 0)
+        fail("short regexp scan polled the interrupt handler unexpectedly");
+}
+
+static void run_long_scan(JSRuntime *rt, JSContext *ctx,
+                          const char *expression)
+{
+    run_case(rt, ctx, expression, 1, 1);
+    run_case(rt, ctx, expression, 0, 1);
+}
+
+int main(void)
+{
+    JSRuntime *rt;
+    JSContext *ctx;
+
+    rt = JS_NewRuntime();
+    if (!rt)
+        fail("could not create runtime");
+    ctx = JS_NewContext(rt);
+    if (!ctx)
+        fail("could not create context");
+
+    eval_setup(ctx, "globalThis.subject8 = 'a'.repeat(1024 * 1024);"
+                    "globalThis.sparse8 = 'x'.repeat(1024 * 1024);"
+                    "globalThis.subject16 = '\\u0100'.repeat(1024 * 1024);");
+
+    run_long_scan(rt, ctx, "!/zzzzzz/.test(subject8)");
+    run_long_scan(rt, ctx, "!/\\x61aaaab/.test(subject8)");
+    run_long_scan(rt, ctx, "!/abcdef[0-9]+/.test(sparse8)");
+    run_long_scan(rt, ctx, "!/[a-z]bcdef/.test(sparse8)");
+    run_long_scan(rt, ctx, "!/(^|[^\\\\])\"target\"/.test(subject8)");
+    run_long_scan(rt, ctx, "!/(?:^|.)abcd/.test(subject16)");
+    run_long_scan(rt, ctx,
+                  "subject8.replace(/zzzzzz/g, 'X') === subject8");
+
+    run_case(rt, ctx, "/aaaa/.test(subject8)", 0, 0);
+
+    JS_FreeContext(ctx);
+    JS_FreeRuntime(rt);
+    return 0;
+}

--- a/tests/test_regexp_threads.c
+++ b/tests/test_regexp_threads.c
@@ -1,0 +1,90 @@
+/* RegExp stress with one independent runtime and context per native thread. */
+
+#include <pthread.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "quickjs.h"
+
+#define THREAD_COUNT 4
+
+typedef struct ThreadState {
+    int index;
+    int failed;
+} ThreadState;
+
+static const char regexp_stress_source[] =
+    "for (let i = 0; i < 500; i++) {\n"
+    "  let re = /abcdef[0-9]+/g;\n"
+    "  re.compile(i & 1 ? '(a|b)+' : '[a-z]bcdef', i & 1 ? 'g' : '');\n"
+    "  let match = re.exec(i & 1 ? 'bbbb' : '00xbcdef');\n"
+    "  if (!match || (i & 1 ? match[0] !== 'bbbb' : match[0] !== 'xbcdef'))\n"
+    "    throw new Error('compile transition mismatch');\n"
+    "  if ('00\\\"x\\\" \\\\\\\"x\\\"'.replace(/(^|[^\\\\])\\\"x\\\"/g, 'X') !== '0X \\\\\\\"x\\\"')\n"
+    "    throw new Error('leading candidate mismatch');\n"
+    "}\n";
+
+static void *regexp_thread(void *opaque)
+{
+    ThreadState *state = opaque;
+    JSRuntime *rt;
+    JSContext *ctx;
+    JSValue result;
+
+    rt = JS_NewRuntime();
+    if (!rt) {
+        state->failed = 1;
+        return NULL;
+    }
+    JS_UpdateStackTop(rt);
+    ctx = JS_NewContext(rt);
+    if (!ctx) {
+        JS_FreeRuntime(rt);
+        state->failed = 1;
+        return NULL;
+    }
+    result = JS_Eval(ctx, regexp_stress_source,
+                     strlen(regexp_stress_source),
+                     "regexp-thread-test.js", JS_EVAL_TYPE_GLOBAL);
+    if (JS_IsException(result)) {
+        JSValue exception = JS_GetException(ctx);
+        const char *message = JS_ToCString(ctx, exception);
+
+        fprintf(stderr, "regexp thread %d failed: %s\n", state->index,
+                message ? message : "unknown exception");
+        JS_FreeCString(ctx, message);
+        JS_FreeValue(ctx, exception);
+        state->failed = 1;
+    }
+    JS_FreeValue(ctx, result);
+    JS_FreeContext(ctx);
+    JS_FreeRuntime(rt);
+    return NULL;
+}
+
+int main(void)
+{
+    pthread_t threads[THREAD_COUNT];
+    ThreadState states[THREAD_COUNT];
+    int i, created;
+
+    created = 0;
+    for(i = 0; i < THREAD_COUNT; i++) {
+        states[i].index = i;
+        states[i].failed = 0;
+        if (pthread_create(&threads[i], NULL, regexp_thread, &states[i])) {
+            fprintf(stderr, "could not create regexp thread %d\n", i);
+            break;
+        }
+        created++;
+    }
+    for(i = 0; i < created; i++)
+        pthread_join(threads[i], NULL);
+    if (created != THREAD_COUNT)
+        return 1;
+    for(i = 0; i < THREAD_COUNT; i++) {
+        if (states[i].failed)
+            return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
Depends on #541. This branch starts at the exact head commit of #541 (`a2c571acad9a4079fc0e29aacc4da7bbef94d4ff`). Once #541 is merged, this PR reduces to three RegExp-only commits and 11 changed files. No Date optimization is included.

## Summary

- validate serialized function and RegExp bytecode, metadata, branch targets, operands, captures, ranges, and group-name trailers before execution
- add bounded, versioned RegExp optimization metadata for literals, prefixes, quick checks, scan entries, and leading-character candidates
- accelerate raw and escaped literals, conservative required prefixes, complex-branch candidate filtering, and global replacement
- reduce replacement-template parsing and common capture-array allocation overhead
- replace runtime opcode-shape probing with a compiler-produced execution descriptor while retaining the generic interpreter as the semantic fallback
- refresh borrowed metadata on every `RegExp.prototype.compile()` transition
- preserve interrupt semantics with bounded polling in every accelerated unbounded scan
- keep interpreter and capture stacks configurable for constrained arm32/arm64 builds

## Design and compatibility

Optimization metadata is treated as untrusted when it comes from serialized bytecode. Valid source-compiled and checked-QBC patterns use the same validated descriptor; patterns that cannot be proven eligible continue through `lre_exec()`. The implementation adds no JIT, executable memory, architecture-specific assembly, or shared mutable global state.

The binary-object version is bumped because the metadata layout changes. Old or malformed QBC is rejected cleanly instead of being interpreted with incompatible optimization state.

## Performance

Fresh seven-run medians on macOS 15.7.4 arm64, Apple clang 17.0.0, `-O2`. The before build is the exact #541 head and the after build is this PR head. Times are ns/op; lower is better.

| QuickJS microbench | Before | After | Change |
| --- | ---: | ---: | ---: |
| `regexp_ascii` | 128.60 | 76.00 | 1.69x faster |
| `regexp_utf16` | 130.65 | 76.60 | 1.71x faster |
| `regexp_replace` | 651.50 | 188.40 | 3.46x faster |
| sum of the three medians | 910.75 | 341.00 | 2.67x faster |

The prefix and quick-check tiers were also measured against otherwise identical builds with their metadata emission disabled:

| Candidate filter | Late hit | Miss |
| --- | ---: | ---: |
| required prefix | 2.86x faster | 5.24x faster |
| multi-character quick check | 2.44x faster | 3.62x faster |

### ahaoboy/js-engine-benchmark

Benchmark commit: `81415304391884c41601d8e7fd4ebf1cbc6385e6`. Scores are higher-is-better.

| Suite | Before | After | Change | Runs |
| --- | ---: | ---: | ---: | ---: |
| isolated RegExp | 567 | 1723 | 3.04x | 7-run median |
| RegExp in full suite | 564 | 1685 | 2.99x | 3-run median |
| full suite score | 1821 | 2078 | +14.11% | 3-run median |

The non-RegExp subtests remained broadly flat; the full-score increase is driven by the RegExp workload.

### Serialized metadata size

A fixture with 1,000 raw literals of 256 code units measured:

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| QBC size | 1,364,423 bytes | 1,116,423 bytes | -18.2% |
| median RSS | 5,439,488 bytes | 4,358,144 bytes | -19.9% |

## Correctness and hardening

- `RegExp.prototype.compile()` transition matrix covers metadata-to-generic and metadata-to-metadata replacements, flags, `lastIndex`, captures, indices, replacement, failures, and GC stress
- direct differential tests compare descriptor execution with the generic interpreter over deterministic randomized inputs
- malformed metadata, opcodes, jumps, capture indexes, old versions, and recomputed-checksum QBC mutations are rejected before script execution
- long 8-bit/UTF-16 atom, prefix, quick-check, leading-candidate, and global-replace scans test both interrupt continuation and timeout propagation
- independent-runtime pthread stress verifies there is no cross-runtime shared state

## Verification

- `make test` on the exact official stacked branch
- source and generated-QBC execution
- Werror, ASan, UBSan, TSan, and macOS leak checks
- 1,491 relevant fixed-commit Test262 RegExp/String integration tests passed with no error
- Android armv7a/aarch64 and iOS device/simulator arm64 compilation
- focused source and QBC hardening benchmarks remained within the 3% regression gate

This PR contains the RegExp changes derived from `a6088bb2ad78365e84fd6955dc6fe14d523925cd`, `63df7cc81b5136455971d9705aea94553c4d6fc4`, and `c2ca48b03498d3cf28b21d7a32a5d1b856b1dec0`.