### PR TITLE
Reject overflowing integers in bytecode reader

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -38500,7 +38500,19 @@ static int bc_get_sleb128(BCReaderState *s, int32_t *pval)
 /* XXX: used to read an `int` with a positive value */
 static int bc_get_leb128_int(BCReaderState *s, int *pval)
 {
-    return bc_get_leb128(s, (uint32_t *)pval);
+    uint32_t val;
+
+    if (bc_get_leb128(s, &val)) {
+        *pval = 0;
+        return -1;
+    }
+    if (unlikely(val > INT_MAX)) {
+        *pval = 0;
+        JS_ThrowSyntaxError(s->ctx, "integer overflow while reading bytecode");
+        return s->error_state = -1;
+    }
+    *pval = val;
+    return 0;
 }
 
 static int bc_get_leb128_u16(BCReaderState *s, uint16_t *pval)

--- a/tests/bjson.c
+++ b/tests/bjson.c
@@ -45,6 +45,8 @@ static JSValue js_bjson_read(JSContext *ctx, JSValueConst this_val,
     flags = 0;
     if (JS_ToBool(ctx, argv[3]))
         flags |= JS_READ_OBJ_REFERENCE;
+    if (JS_ToBool(ctx, argv[4]))
+        flags |= JS_READ_OBJ_BYTECODE;
     obj = JS_ReadObject(ctx, buf + pos, len, flags);
     return obj;
 }
@@ -69,7 +71,7 @@ static JSValue js_bjson_write(JSContext *ctx, JSValueConst this_val,
 }
 
 static const JSCFunctionListEntry js_bjson_funcs[] = {
-    JS_CFUNC_DEF("read", 4, js_bjson_read ),
+    JS_CFUNC_DEF("read", 5, js_bjson_read ),
     JS_CFUNC_DEF("write", 2, js_bjson_write ),
 };
 

--- a/tests/test_bjson.js
+++ b/tests/test_bjson.js
@@ -179,6 +179,24 @@ function bjson_test_reference()
     }
 }
 
+function bjson_test_invalid_bytecode_count()
+{
+    var buf, rejected;
+
+    buf = new Uint8Array([
+        0x05, 0x00, 0x0c, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x01, 0x00, 0x00, 0xff, 0xff, 0xff,
+        0xff, 0x0f, 0x00, 0x00,
+    ]);
+    rejected = false;
+    try {
+        bjson.read(buf.buffer, 0, buf.byteLength, false, true);
+    } catch(e) {
+        rejected = e instanceof SyntaxError;
+    }
+    assert(rejected);
+}
+
 function bjson_test_all()
 {
     var obj;
@@ -219,6 +237,7 @@ function bjson_test_all()
 
     bjson_test_arraybuffer();
     bjson_test_reference();
+    bjson_test_invalid_bytecode_count();
 }
 
 bjson_test_all();


### PR DESCRIPTION
## Summary

- decode positive `int` fields through a `uint32_t` temporary
- reject unsigned LEB128 values above `INT_MAX` before assigning signed bytecode fields
- add a regression for the overflowing constant-pool count from #549

## Problem

`bc_get_leb128_int()` previously wrote an unsigned LEB128 value directly through an `int *`. Values above `INT_MAX` therefore became negative. In `JS_ReadFunctionTag()`, a negative count could wrap the allocation-size calculation below the bytecode-function header size before the header copy.

The shared decoder now raises a `SyntaxError` for values that cannot be represented by its positive `int` callers. This also removes the incompatible pointer cast.

Fixes #549.

## Testing

- `make -j4 test`
- `make -j4 CONFIG_ASAN=y CONFIG_UBSAN=y test`
- exact 21-byte reproducer: baseline reports a 96-byte heap-buffer-overflow write; patched build rejects it with `SyntaxError: integer overflow while reading bytecode`