### PR TITLE
support regexp buffer boundaries

### DIFF
--- a/libregexp-opcode.h
+++ b/libregexp-opcode.h
@@ -37,6 +37,7 @@ DEF(line_start, 1)
 DEF(line_start_m, 1)
 DEF(line_end, 1)
 DEF(line_end_m, 1)
+DEF(line_end_z, 1) /* optional line terminator or "\r\n" followed by buffer end */
 DEF(goto, 5)
 DEF(split_goto_first, 5)
 DEF(split_next_first, 5)

--- a/libregexp.c
+++ b/libregexp.c
@@ -2089,6 +2089,27 @@ static int re_parse_term(REParseState *s, BOOL is_backward_dir)
                 p = p1;
             }
             break;
+        case 'A':
+            if (s->is_unicode) {
+                p += 2;
+                re_emit_op(s, REOP_line_start);
+                break;
+            }
+            goto parse_class_atom;
+        case 'z':
+            if (s->is_unicode) {
+                p += 2;
+                re_emit_op(s, REOP_line_end);
+                break;
+            }
+            goto parse_class_atom;
+        case 'Z':
+            if (s->is_unicode) {
+                p += 2;
+                re_emit_op(s, REOP_line_end_z);
+                break;
+            }
+            goto parse_class_atom;
         case '0':
             p += 2;
             c = 0;
@@ -2994,13 +3015,28 @@ static intptr_t lre_exec_backtrack(REExecContext *s, uint8_t **capture,
             break;
         case REOP_line_end:
         case REOP_line_end_m:
-            if (cptr == cbuf_end)
-                break;
-            if (opcode == REOP_line_end)
-                goto no_match;
-            PEEK_CHAR(c, cptr, cbuf_end, cbuf_type);
-            if (!is_line_terminator(c))
-                goto no_match;
+        case REOP_line_end_z:
+            {
+                const uint8_t *cptr1 = cptr;
+                if (cptr1 == cbuf_end)
+                    break;
+                if (opcode == REOP_line_end)
+                    goto no_match;
+                GET_CHAR(c, cptr1, cbuf_end, cbuf_type);
+                if (!is_line_terminator(c))
+                    goto no_match;
+                if (opcode == REOP_line_end_z && cptr1 != cbuf_end) {
+                    if (c == '\r') {
+                        /* allow "\r\n" at end of buffer */
+                        GET_CHAR(c, cptr1, cbuf_end, cbuf_type);
+                        if (c != '\n' || cptr1 != cbuf_end) {
+                            goto no_match;
+                        }
+                    } else {
+                        goto no_match;
+                    }
+                }
+            }
             break;
         case REOP_dot:
             if (cptr == cbuf_end)

--- a/test262.conf
+++ b/test262.conf
@@ -179,6 +179,7 @@ Reflect
 Reflect.construct
 Reflect.set
 Reflect.setPrototypeOf
+regexp-buffer-boundaries
 regexp-dotall
 regexp-duplicate-named-groups
 regexp-lookbehind


### PR DESCRIPTION
Hello, this implements the stage 3 RegExp Buffer Boundaries proposal: https://github.com/tc39/proposal-regexp-buffer-boundaries

I tested against this test262 PR: https://github.com/tc39/test262/pull/4975

There were two failing tests from `./run-test262 -c test262.conf` and `./run-test262-debug -c test262.conf`:
```
test262/test/built-ins/RegExp/unicode_restricted_identity_escape_alpha.js:17: unexpected error: Test262Error: IdentityEscape in AtomEscape: 'A' Expected a SyntaxError to be thrown but no exception was thrown at all
test262/test/language/module-code/namespace/internals/super-access-to-tdz-binding.js:32: unexpected error: Test262Error: Expected a ReferenceError but got a TypeError
Result: 50/43781 errors, 3382 excluded, 6102 skipped, 2 new
```

The first failure is a test that had not been updated to allow these new escapes, so I have left a note on the test262 PR: https://github.com/tc39/test262/pull/4975#issuecomment-5413172172. The second seems to be a new test that is unrelated to my changes.

I have not updated the test262 commit in this repository because the test262 PR has not been merged yet.

Closes #544 