### PR TITLE
Fix/allocator size overflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ qjscalc.c
 repl.c
 run-test262
 run-test262.exe
+test_malloc
+test_malloc.exe
 test262
 test262_*.txt
 test262o

--- a/Makefile
+++ b/Makefile
@@ -213,6 +213,7 @@ endif
 endif
 
 PROGS=qjs$(EXE) qjsc$(EXE) run-test262$(EXE)
+TEST_PROGS=test_malloc$(EXE)
 
 ifneq ($(CROSS_PREFIX),)
 QJSC_CC=gcc
@@ -262,6 +263,9 @@ LIBS+=$(EXTRA_LIBS)
 
 $(OBJDIR):
 	mkdir -p $(OBJDIR) $(OBJDIR)/examples $(OBJDIR)/tests
+
+$(OBJDIR)/tests:
+	mkdir -p $@
 
 qjs$(EXE): $(QJS_OBJS)
 	$(CC) $(LDFLAGS) $(LDEXPORT) -o $@ $^ $(LIBS)
@@ -367,7 +371,7 @@ unicode_gen: $(OBJDIR)/unicode_gen.host.o $(OBJDIR)/cutils.host.o libunicode.c u
 
 clean:
 	rm -f repl.c out.c
-	rm -f *.a *.o *.d *~ unicode_gen regexp_test fuzz_eval fuzz_compile fuzz_regexp $(PROGS)
+	rm -f *.a *.o *.d *~ unicode_gen regexp_test fuzz_eval fuzz_compile fuzz_regexp $(PROGS) $(TEST_PROGS)
 	rm -f hello.c test_fib.c
 	rm -f examples/*.so tests/*.so
 	rm -rf $(OBJDIR)/ *.dSYM/ qjs-debug$(EXE)
@@ -452,7 +456,13 @@ ifdef CONFIG_SHARED_LIBS
 test: tests/bjson.so examples/point.so
 endif
 
-test: qjs$(EXE)
+test_malloc$(EXE): $(OBJDIR)/tests/test_malloc.o libquickjs$(LTOEXT).a
+	$(CC) $(LDFLAGS) -o $@ $^ $(LIBS)
+
+$(OBJDIR)/tests/test_malloc.o: | $(OBJDIR)/tests
+
+test: qjs$(EXE) $(TEST_PROGS)
+	$(WINE) ./test_malloc$(EXE)
 	$(WINE) ./qjs$(EXE) tests/test_closure.js
 	$(WINE) ./qjs$(EXE) tests/test_language.js
 	$(WINE) ./qjs$(EXE) --std tests/test_builtin.js

--- a/quickjs.c
+++ b/quickjs.c
@@ -1546,10 +1546,17 @@ static no_inline void *js_malloc_large(JSMallocContext *s, size_t size)
     return b->header.user_data;
 }
 
+static inline BOOL js_malloc_size_is_valid(size_t size)
+{
+    return size <= SIZE_MAX - (JS_MALLOC_ALIGN - 1) - sizeof(JSMallocLargeBlockHeader);
+}
+
 static void *__js_malloc(JSMallocContext *s, size_t size)
 {
     size_t total_size;
-    if (unlikely(size == 0)) {
+    if (unlikely(!js_malloc_size_is_valid(size))) {
+        return NULL;
+    } else if (unlikely(size == 0)) {
         JSMallocBlockHeader *b = get_zero_size_block(s);
         return b->user_data;
     } else {
@@ -1636,7 +1643,9 @@ static void __js_free(JSMallocContext *s, void *ptr)
 static void *__js_realloc(JSMallocContext *s, void *ptr, size_t size)
 {
     JSMallocBlockHeader *b;
-    if (ptr == NULL) {
+    if (unlikely(!js_malloc_size_is_valid(size))) {
+        return NULL;
+    } else if (ptr == NULL) {
         return __js_malloc(s, size);
     } else if (size == 0) {
         __js_free(s, ptr);
@@ -2157,7 +2166,8 @@ static void *js_def_malloc(JSMallocState *s, size_t size)
     /* Do not allocate zero bytes: behavior is platform dependent */
     assert(size != 0);
 
-    if (unlikely(s->malloc_size + size > s->malloc_limit))
+    if (unlikely(s->malloc_size > s->malloc_limit ||
+                 size > s->malloc_limit - s->malloc_size))
         return NULL;
 
     ptr = malloc(size);
@@ -2195,7 +2205,9 @@ static void *js_def_realloc(JSMallocState *s, void *ptr, size_t size)
         free(ptr);
         return NULL;
     }
-    if (s->malloc_size + size - old_size > s->malloc_limit)
+    if (s->malloc_size < old_size ||
+        s->malloc_size - old_size > s->malloc_limit ||
+        size > s->malloc_limit - (s->malloc_size - old_size))
         return NULL;
 
     ptr = realloc(ptr, size);

--- a/tests/test_malloc.c
+++ b/tests/test_malloc.c
@@ -1,0 +1,31 @@
+#include "../quickjs.h"
+
+#include <stdint.h>
+
+int main(void)
+{
+    JSRuntime *rt = JS_NewRuntime();
+    uint8_t *ptr;
+
+    if (rt == NULL)
+        return 1;
+
+    if (js_malloc_rt(rt, SIZE_MAX) != NULL)
+        return 2;
+    if (js_mallocz_rt(rt, SIZE_MAX) != NULL)
+        return 3;
+
+    ptr = js_malloc_rt(rt, 16);
+    if (ptr == NULL)
+        return 4;
+    ptr[0] = 0x41;
+
+    if (js_realloc_rt(rt, ptr, SIZE_MAX) != NULL)
+        return 5;
+    if (ptr[0] != 0x41)
+        return 6;
+
+    js_free_rt(rt, ptr);
+    JS_FreeRuntime(rt);
+    return 0;
+}


### PR DESCRIPTION
## Problem

The allocator aligns each requested size and adds an internal block header. For values near `SIZE_MAX`, these calculations can wrap and make an oversized request appear to be a small allocation.

As a result, `js_malloc_rt()` can return an undersized block for an unrepresentable request. The same issue affects allocation and reallocation paths, while the default allocator's memory-limit checks also contain arithmetic that can wrap before comparison.

## Fix

- Reject sizes that cannot accommodate alignment and the largest internal block header.
- Apply the validation to allocation and reallocation paths.
- Rewrite the default allocator's limit checks using checked subtraction.
- Add regression coverage for `SIZE_MAX` allocation, zeroed allocation, and reallocation requests.

A failed reallocation continues to preserve the original allocation and its contents.

## Testing

- `make -j8 test`
- `make CONFIG_ASAN=y CONFIG_UBSAN=y -j8 test`
- LTO and warning-as-error builds